### PR TITLE
WIP: Improve identity parsing

### DIFF
--- a/SQRLConsoleTester/Program.cs
+++ b/SQRLConsoleTester/Program.cs
@@ -23,10 +23,8 @@ namespace SQRLConsoleTester
                 Console.WriteLine($"{percent.Value}: {percent.Key}%");
             });
 
-            //SQRLIdentity newId = SQRL.ImportSqrlIdentityFromFile(Path.Combine(Directory.GetCurrentDirectory(), @"Spec-Vectors-Identity_2.sqrl"));
-            SQRLIdentity newId = SQRL.ImportSqrlIdentityFromFile(@"C:\temp\SQRL\newnew2.sqrl");
-
-            
+            //SQRLIdentity newId = SQRLIdentity.FromFile(Path.Combine(Directory.GetCurrentDirectory(), @"Spec-Vectors-Identity_2.sqrl"));
+            SQRLIdentity newId = SQRLIdentity.FromFile(@"C:\temp\SQRL\newnew2.sqrl");
 
             SQRLOpts optsFlags = (sqrl.cps != null && sqrl.cps.Running ? SQRLOpts.SUK | SQRLOpts.CPS : SQRLOpts.SUK);
 

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -656,43 +656,6 @@ namespace SQRLUtilsLib
         }
 
         /// <summary>
-        /// Imports the SQRL Identity from a File 
-        /// </summary>
-        /// <param name="file"></param>
-        /// <returns></returns>
-        public static SQRLIdentity ImportSqrlIdentityFromFile(string file)
-        {
-            SQRLIdentity id = null;
-
-            if (File.Exists(file))
-            {
-                byte[] fileBytes = File.ReadAllBytes(file);
-                string sqrlData = System.Text.Encoding.UTF8.GetString(fileBytes.Take(8).ToArray());
-                if (sqrlData.Equals("sqrldata", StringComparison.OrdinalIgnoreCase))
-                {
-                    byte[] block1 = fileBytes.Skip(8).Take(125).ToArray();
-                    id = new SQRLIdentity();
-                    id.Block1.FromByteArray(block1);
-                    byte[] block2 = fileBytes.Skip(133).Take(73).ToArray();
-                    id.Block2.FromByteArray(block2);
-                    if (fileBytes.Length > 133 + 73)
-                    {
-                        var block3Length = BitConverter.ToUInt16(fileBytes.Skip(133 + 73).Take(2).ToArray());
-
-                        byte[] block3 = fileBytes.Skip(133 + 73).Take(block3Length).ToArray();
-                        id.Block3.FromByteArray(block3);
-                    }
-
-                }
-                else
-                    throw new IOException("Invalid File Exception, not a valid SQRL Identity File");
-            }
-
-            return id;
-        }
-
-
-        /// <summary>
         ///  //Decrypts SQRL Identity Block 1
         /// </summary>
         /// <param name="identity"></param>


### PR DESCRIPTION
See issue #1 

**Changes**
- Remove `SQRL.ImportSqrlIdentityFromFile()`
- Add `SQRLIdentity.FromFile()` to replace the above
- Add `SQRLIdentity.FromByteArray()` for more flexibility
- Use a list for storing identity blocks instead of properties
- Keep the `Block1`, `Block2` and `Block3` public properties but make them fetch the blocks from the new block list
- Add `SQRLBlock` inner class to represent unknown block types
- Change identity parsing to be agnostic of block type and block order

This PR aims at making the identity parsing much more flexible and future-proof. It enables support for retaining unknown block types.

**Notes**
**** THIS IS A WORK IN PROGRESS AND IS NOT EXTENSIVELY TESTED YET ****

@josegomez, I would like to discuss if this is something worth considering before going ahead with further testing and polishing, or if you don't like the new apporach.

Looking foward to your input.