### PR TITLE
Enable identity selection in auth dialog

### DIFF
--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -13,7 +13,7 @@
     { "NewAccountQuestion": "The server at {0} did not recognize this Identity, would you like to proceed? This may cause the site to create a new account for this Identity" },
     { "GenericQuestionTitle": "Question?" },
     { "AskHeader": "Question from: {0}" },
-    { "AltIDLabel": "Alt ID" },
+    { "AltIDLabel": "Alt-ID:" },
     { "DisableAccountAlert": "This will DISABLE all use of SQRL in the Given Site {0}, note that this operation is not easily reversed.{1}You will need your Rescue Code to enable SQRL in the future.{1}Would you like to continue?" },
     { "SelectIdentityLabel": "Select an identity:" },
     { "SelectIdentityTitle": "Select identity" },
@@ -98,7 +98,9 @@
     { "PasswordLabel": "Password:" },
     { "NewIdentityWindowTitle": "SQRL Client - New Identity" },
     { "NewIdentityMessage": "To generate a new identity you need to save the rescue code shown below and enter a password. You REALLY need to save and store the rescue code in a save place, it will be required later!" },
-    { "PasswordsDontMatchErrorMessage": "The entered passwords don't match!\nPlease try again." }
+    { "PasswordsDontMatchErrorMessage": "The entered passwords don't match!\nPlease try again." },
+    { "ShowAdvancedFunctionsLabel": "Show advanced functions" },
+    { "WithIdentityLabel": "with identity" }
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -114,7 +116,7 @@
     { "NewAccountQuestion": "The server at {0} did not recognize this Identity, would you like to proceed? This may cause the site to create a new account for this Identity" },
     { "GenericQuestionTitle": "Question?" },
     { "AskHeader": "Question from: {0}" },
-    { "AltIDLabel": "Alt ID" },
+    { "AltIDLabel": "Alt-ID:" },
     { "DisableAccountAlert": "This will DISABLE all use of SQRL in the Given Site {0}, note that this operation is not easily reversed.{1}You will need your Rescue Code to enable SQRL in the future.{1}Would you like to continue?" },
     { "SelectIdentityLabel": "Select an identity:" },
     { "SelectIdentityTitle": "Select identity" },
@@ -198,7 +200,9 @@
     { "PasswordLabel": "Password:" },
     { "NewIdentityWindowTitle": "SQRL Client - New Identity" },
     { "NewIdentityMessage": "To generate a new identity you need to save the rescue code shown below and enter a password. You REALLY need to save and store the rescue code in a save place, it will be required later!" },
-    { "PasswordsDontMatchErrorMessage": "The entered passwords don't match!\nPlease try again." }
+    { "PasswordsDontMatchErrorMessage": "The entered passwords don't match!\nPlease try again." },
+    { "ShowAdvancedFunctionsLabel": "Show advanced functions" },
+    { "WithIdentityLabel": "with identity" }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -214,7 +218,7 @@
     { "NewAccountQuestion": "Der Server auf {0} hat diese Identität nicht erkannt. Möchten Sie trotzdem fortfahren? Dies könnte bedeuten, dass der Server einen neuen Account für diese Identität erstellt." },
     { "GenericQuestionTitle": "Frage" },
     { "AskHeader": "Frage von: {0}" },
-    { "AltIDLabel": "Alt-ID" },
+    { "AltIDLabel": "Alt-ID:" },
     { "DisableAccountAlert": "Dieser Vorgang deaktiviert die Anmeldung mittels SQRL auf {0} vollständig. Bitte beachten Sie, dass dieser Vorgang nicht ohne weiteres rückgängig gemacht werden kann.{1}Sie benötigen Ihren Rettungsschlüssel (\"rescue code\"), um SQRL später wieder zu aktivieren.{1}Möchten Sie fortfahren?" },
     { "SelectIdentityLabel": "Wählen Sie eine Identität:" },
     { "SelectIdentityTitle": "Identität wählen" },
@@ -298,6 +302,8 @@
     { "PasswordLabel": "Passwort:" },
     { "NewIdentityWindowTitle": "SQRL Client - Neue Identität" },
     { "NewIdentityMessage": "Um eine neue Identität zu erstellen, notieren Sie den angezeigten Rettungscode und vergeben Sie ein Passwort. Speichern bzw. verwahren Sie den Rettungscode unbedingt an einem sicheren Ort, Sie werden ihn später noch benötigen!" },
-    { "PasswordsDontMatchErrorMessage": "Die eingegebenen Passwörter stimmen nicht überein!\nBitte versuchen Sie es erneut." }
+    { "PasswordsDontMatchErrorMessage": "Die eingegebenen Passwörter stimmen nicht überein!\nBitte versuchen Sie es erneut." },
+    { "ShowAdvancedFunctionsLabel": "Erweiterte Funktionen anzeigen" },
+    { "WithIdentityLabel": "mit Identität" }
   ]
 }

--- a/SQRLDotNetClientUI/Models/IdentityManager.cs
+++ b/SQRLDotNetClientUI/Models/IdentityManager.cs
@@ -157,6 +157,9 @@ namespace SQRLDotNetClientUI.Models
             {
                 SetCurrentIdentity(null);
             }
+
+            // Fire the IdentityCountChanged event
+            IdentityCountChanged?.Invoke(this, new IdentityCountChangedEventArgs(this.IdentityCount));
         }
 
         /// <summary>
@@ -195,6 +198,9 @@ namespace SQRLDotNetClientUI.Models
             {
                 SetCurrentIdentity(newIdRec.UniqueId);
             }
+
+            // Finally, fire the IdentityCountChanged event
+            IdentityCountChanged?.Invoke(this, new IdentityCountChangedEventArgs(this.IdentityCount));
         }
 
         /// <summary>
@@ -299,6 +305,11 @@ namespace SQRLDotNetClientUI.Models
         /// This event is raised if the currently selected identity changes.
         /// </summary>
         public event EventHandler<IdentityChangedEventArgs> IdentityChanged;
+
+        /// <summary>
+        /// This event is raised if the number of available identities changes.
+        /// </summary>
+        public event EventHandler<IdentityCountChangedEventArgs> IdentityCountChanged;
     }
 
     public class IdentityChangedEventArgs : EventArgs
@@ -312,6 +323,16 @@ namespace SQRLDotNetClientUI.Models
             this.Identity = identity;
             this.IdentityName = identityName;
             this.IdentityUniqueId = identityUniqueId;
+        }
+    }
+
+    public class IdentityCountChangedEventArgs : EventArgs
+    {
+        public int IdentityCount { get; }
+
+        public IdentityCountChangedEventArgs(int identityCount)
+        {
+            this.IdentityCount = identityCount;
         }
     }
 }

--- a/SQRLDotNetClientUI/Properties/launchSettings.json
+++ b/SQRLDotNetClientUI/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "SQRLDotNetClientUI": {
-      "commandName": "Project",
-      "commandLineArgs": "sqrl://www.grc.com/sqrl?nut=1LIddXo3wlDx2GrCoB_l-w"
+      "commandName": "Project"
     }
   }
 }

--- a/SQRLDotNetClientUI/Properties/launchSettings.json
+++ b/SQRLDotNetClientUI/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "SQRLDotNetClientUI": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "sqrl://www.grc.com/sqrl?nut=1LIddXo3wlDx2GrCoB_l-w"
     }
   }
 }

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -40,11 +40,19 @@ namespace SQRLDotNetClientUI.ViewModels
         public bool AuthAction { get; set; }
 
         public string _siteID = "";
-        public string SiteID { get { return $"{this.Site.Host}"; } set => this.RaiseAndSetIfChanged(ref _siteID, value); }
+        public string SiteID 
+        { 
+            get { return $"{this.Site.Host}"; } 
+            set => this.RaiseAndSetIfChanged(ref _siteID, value); 
+        }
 
         private int _Block1Progress = 0;
 
-        public int Block1Progress { get => _Block1Progress; set => this.RaiseAndSetIfChanged(ref _Block1Progress, value); }
+        public int Block1Progress 
+        { 
+            get => _Block1Progress; 
+            set => this.RaiseAndSetIfChanged(ref _Block1Progress, value); 
+        }
 
         public int MaxProgress { get => 100; }
 
@@ -52,6 +60,7 @@ namespace SQRLDotNetClientUI.ViewModels
         {
             Init();
             this.Site = new Uri("https://google.com");
+            this.SiteID = this.Site.Host;
         }
 
         public AuthenticationViewModel(Uri site)

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -1,5 +1,4 @@
-﻿using Avalonia;
-using ReactiveUI;
+﻿using ReactiveUI;
 using Sodium;
 using SQRLDotNetClientUI.Views;
 using SQRLUtilsLib;
@@ -10,6 +9,8 @@ using System.Text;
 using SQRLDotNetClientUI.Utils;
 using MessageBox.Avalonia.Enums;
 using MessageBox.Avalonia;
+using Avalonia.Controls;
+using SQRLDotNetClientUI.Models;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
@@ -25,17 +26,15 @@ namespace SQRLDotNetClientUI.ViewModels
         private LoginAction action = LoginAction.Login;
         public LoginAction Action
         {
-            get => action; set
-            {
-                this.RaiseAndSetIfChanged(ref action, value);
-            }
+            get => action; 
+            set { this.RaiseAndSetIfChanged(ref action, value); }
         }
 
         private SQRL _sqrlInstance = SQRL.GetInstance(true);
 
         public Uri Site { get; set; }
         public string AltID { get; set; }
-        public string Password { get; set; }
+        public string Password { get; set; } = "";
 
         public bool AuthAction { get; set; }
 
@@ -44,6 +43,27 @@ namespace SQRLDotNetClientUI.ViewModels
         { 
             get { return $"{this.Site.Host}"; } 
             set => this.RaiseAndSetIfChanged(ref _siteID, value); 
+        }
+
+        public string _identityName = "";
+        public string IdentityName
+        {
+            get => _identityName;
+            set => this.RaiseAndSetIfChanged(ref _identityName, value);
+        }
+
+        public bool _showIdentitySelector;
+        public bool ShowIdentitySelector
+        {
+            get => _showIdentitySelector;
+            set => this.RaiseAndSetIfChanged(ref _showIdentitySelector, value);
+        }
+
+        public bool _advancedFunctionsVisible = false;
+        public bool AdvancedFunctionsVisible
+        {
+            get => _advancedFunctionsVisible;
+            set => this.RaiseAndSetIfChanged(ref _advancedFunctionsVisible, value);
         }
 
         private int _Block1Progress = 0;
@@ -73,6 +93,35 @@ namespace SQRLDotNetClientUI.ViewModels
         private void Init()
         {
             this.Title = _loc.GetLocalizationValue("AuthenticationWindowTitle");
+            this.IdentityName = _identityManager.CurrentIdentity?.IdentityName;
+            _identityManager.IdentityChanged += IdentityChanged;
+            _identityManager.IdentityCountChanged += IdentityCountChanged;
+
+            IdentityCountChanged(this, new IdentityCountChangedEventArgs(
+                _identityManager.IdentityCount));
+        }
+
+        private void IdentityCountChanged(object sender, IdentityCountChangedEventArgs e)
+        {
+            if (e.IdentityCount > 1) this.ShowIdentitySelector = true;
+            else this.ShowIdentitySelector = false;
+        }
+
+        public async void SwitchIdentity()
+        {
+            SelectIdentityDialogView selectIdDialog = new SelectIdentityDialogView();
+            selectIdDialog.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+            await selectIdDialog.ShowDialog(_mainWindow);
+        }
+
+        private void IdentityChanged(object sender, IdentityChangedEventArgs e)
+        {
+            this.IdentityName = e.Identity.IdentityName;
+        }
+
+        public void ShowAdvancedFunctions()
+        {
+            this.AdvancedFunctionsVisible = true;
         }
 
         public void Cancel()

--- a/SQRLDotNetClientUI/Views/AuthenticationView.xaml
+++ b/SQRLDotNetClientUI/Views/AuthenticationView.xaml
@@ -9,10 +9,14 @@
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
              x:Class="SQRLDotNetClientUI.Views.AuthenticationView">
+
+  <!-- Data context -->
   <Design.DataContext>
     <vm:AuthenticationViewModel/>
   </Design.DataContext>
-  <Grid ShowGridLines="False">
+
+  <!-- Begin main layout -->
+  <Grid ShowGridLines="False" Margin="20">
     <Grid.Resources>
       <loc:EnumBooleanConverter x:Key="enumBooleanConverter" />
     </Grid.Resources>
@@ -29,17 +33,25 @@
       <RowDefinition />
       <RowDefinition />
     </Grid.RowDefinitions>
+
+    <!-- Header image -->
     <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
+
+    <!-- Login message and site id -->
     <StackPanel  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal">
     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization AuthMessage}" FontSize="15" TextWrapping="Wrap" />
     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{Binding SiteID}" FontSize="15" TextWrapping="Wrap" Grid.Row="0"/>
     </StackPanel>
+
+    <!-- Password -->
     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization Password}" FontSize="15" TextWrapping="Wrap" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"/>
     <loc:CopyPasteTextBox Text="{Binding Password}" HorizontalAlignment="Left" PasswordChar="*" Grid.Row="1" Grid.Column="1" Width="250" Height="30">
       <i:Interaction.Behaviors>
         <behaviors:FocusOnAttached />
       </i:Interaction.Behaviors>
       </loc:CopyPasteTextBox>
+
+    <!-- Rescue code -->
     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization AltIDLabel}" FontSize="15" TextWrapping="Wrap" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"/>
     <loc:CopyPasteTextBox Text="{Binding AltID}" HorizontalAlignment="Left"  Grid.Row="2" Grid.Column="1" Width="100" Height="30"/>
     <StackPanel Grid.Row="3" Grid.Column="1">
@@ -49,12 +61,17 @@
       <RadioButton  IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Remove}"  Margin="0,2">Remove</RadioButton>
       -->
     </StackPanel>
+
+    <!-- Progress indicator -->
     <ProgressBar  IsIndeterminate="False" Value="{Binding Block1Progress}" Maximum="{Binding MaxProgress}" Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="10"/>
+
+    <!-- Cancel/OK buttons -->
     <Button Command="{Binding Cancel}" Grid.Row="6" Grid.Column="0" Width="100" Height="30" HorizontalAlignment="Left" Margin="10" >
       <TextBlock Text="{loc:Localization BtnCancel}"/>
     </Button>
     <Button Command="{Binding Login}" Grid.Row="6" Grid.Column="1" Width="100" Height="30" HorizontalAlignment="Right" Margin="10" IsDefault="True">
       <TextBlock Text="{loc:Localization BtnOK}"/>
     </Button>
+    
   </Grid>
 </UserControl>

--- a/SQRLDotNetClientUI/Views/AuthenticationView.xaml
+++ b/SQRLDotNetClientUI/Views/AuthenticationView.xaml
@@ -7,71 +7,86 @@
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
              xmlns:util="clr-namespace:SQRLDotNetClientUI.ViewModels.AuthenticationViewModel;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="300"
+             mc:Ignorable="d" d:DesignWidth="450" d:DesignHeight="500"
              x:Class="SQRLDotNetClientUI.Views.AuthenticationView">
 
-  <!-- Data context -->
-  <Design.DataContext>
-    <vm:AuthenticationViewModel/>
-  </Design.DataContext>
-
   <!-- Begin main layout -->
-  <Grid ShowGridLines="False" Margin="20">
-    <Grid.Resources>
-      <loc:EnumBooleanConverter x:Key="enumBooleanConverter" />
-    </Grid.Resources>
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="100"/>
-      <ColumnDefinition Width="*"/>
-    </Grid.ColumnDefinitions>
-    <Grid.RowDefinitions>
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-      <RowDefinition />
-    </Grid.RowDefinitions>
+  <DockPanel Margin="0">
 
     <!-- Header image -->
-    <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Left" VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
+    <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Margin="20" Height="50" DockPanel.Dock="Top" HorizontalAlignment="Center"></Image>
 
     <!-- Login message and site id -->
-    <StackPanel  Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal">
-    <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization AuthMessage}" FontSize="15" TextWrapping="Wrap" />
-    <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{Binding SiteID}" FontSize="15" TextWrapping="Wrap" Grid.Row="0"/>
+      <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Margin="10, 0, 10, 5" Text="{loc:Localization AuthMessage}" FontSize="13" TextWrapping="Wrap" />
+      <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Margin="10, 0, 10, 0" Text="www.grc.com" FontSize="22" FontFamily="Consolas" Foreground="#007cc3" TextWrapping="Wrap"/>
+
+    <!-- "Identity button/label -->
+    <StackPanel IsVisible="{Binding ShowIdentitySelector}" Orientation="Horizontal" DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="5,5,5,0">
+      <Button Command="{Binding SwitchIdentity}" IsVisible="{Binding SwitchIdentity}" Margin="0,5,0,0" BorderBrush="Transparent">
+        <Button.Template>
+          <ControlTemplate>
+            <StackPanel Orientation="Horizontal">
+              <TextBlock Text="{loc:Localization WithIdentityLabel}" Margin="0,0,3,0" />
+              <TextBlock Text="{Binding IdentityName}" Foreground="Blue">Identity Name</TextBlock>
+            </StackPanel>
+          </ControlTemplate>
+        </Button.Template>
+      </Button>
     </StackPanel>
 
-    <!-- Password -->
-    <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization Password}" FontSize="15" TextWrapping="Wrap" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"/>
-    <loc:CopyPasteTextBox Text="{Binding Password}" HorizontalAlignment="Left" PasswordChar="*" Grid.Row="1" Grid.Column="1" Width="250" Height="30">
-      <i:Interaction.Behaviors>
-        <behaviors:FocusOnAttached />
-      </i:Interaction.Behaviors>
+    <!-- Password form -->
+    <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="20,20,10,10">
+      <TextBlock Name="test" Text="{loc:Localization Password}" Width="100" VerticalAlignment="Center" FontSize="14" TextWrapping="Wrap"/>
+      <loc:CopyPasteTextBox Name="txtPassword" Text="{Binding Password}" PasswordChar="*" Width="230" Height="30">
+        <i:Interaction.Behaviors>
+          <behaviors:FocusOnAttached />
+        </i:Interaction.Behaviors>
       </loc:CopyPasteTextBox>
-
-    <!-- Rescue code -->
-    <TextBlock HorizontalAlignment="Left" VerticalAlignment="Center" Margin="10" Text="{loc:Localization AltIDLabel}" FontSize="15" TextWrapping="Wrap" Grid.Row="2" Grid.Column="0" Grid.ColumnSpan="2"/>
-    <loc:CopyPasteTextBox Text="{Binding AltID}" HorizontalAlignment="Left"  Grid.Row="2" Grid.Column="1" Width="100" Height="30"/>
-    <StackPanel Grid.Row="3" Grid.Column="1">
-    <RadioButton Content="{loc:Localization LoginRadioButtonText}" IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Login}" Margin="0,2" />
-    <RadioButton Content="{loc:Localization DisableRadioButtonText}" IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Disable}"  Margin="0,2" />
-      <!--
-      <RadioButton  IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Remove}"  Margin="0,2">Remove</RadioButton>
-      -->
     </StackPanel>
 
-    <!-- Progress indicator -->
-    <ProgressBar  IsIndeterminate="False" Value="{Binding Block1Progress}" Maximum="{Binding MaxProgress}" Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="10"/>
+    <!-- "Show advanced functions" button/label -->
+    <Button Command="{Binding ShowAdvancedFunctions}" IsVisible="{Binding !AdvancedFunctionsVisible}" DockPanel.Dock="Top" 
+            HorizontalAlignment="Center" BorderBrush="Transparent">
+      <Button.Template>
+        <ControlTemplate>
+          <TextBlock Text="{loc:Localization ShowAdvancedFunctionsLabel}" Foreground="Blue" />
+        </ControlTemplate>
+      </Button.Template>
+    </Button>
+
+    <!-- Advanced functions -->
+    <StackPanel DockPanel.Dock="Top" IsVisible="{Binding AdvancedFunctionsVisible}">
+      
+      <!-- Alt-ID -->  
+      <StackPanel Orientation="Horizontal" Margin="20,0,20,0">
+        <TextBlock Text="{loc:Localization AltIDLabel}" Width="100" VerticalAlignment="Center" FontSize="14" TextWrapping="Wrap"/>
+        <loc:CopyPasteTextBox Text="{Binding AltID}" HorizontalAlignment="Left" Width="230" Height="30"/>
+      </StackPanel>
+
+      <!-- Enable/Disable/Remove radio buttons -->
+      <StackPanel Margin="120,15,20,0">
+        <StackPanel.Resources>
+          <loc:EnumBooleanConverter x:Key="enumBooleanConverter" />
+        </StackPanel.Resources>
+        <RadioButton Content="{loc:Localization LoginRadioButtonText}" IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Login}" Margin="0,0,0,2" />
+        <RadioButton Content="{loc:Localization DisableRadioButtonText}" IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Disable}"  Margin="0,2,0,2" />
+        <!--<RadioButton  IsChecked="{Binding Path=Action, Converter={StaticResource enumBooleanConverter}, ConverterParameter=Remove}"  Margin="110,2,2,2">Remove</RadioButton>-->
+      </StackPanel>
+
+    <!-- End advanced functions -->
+    </StackPanel>
 
     <!-- Cancel/OK buttons -->
-    <Button Command="{Binding Cancel}" Grid.Row="6" Grid.Column="0" Width="100" Height="30" HorizontalAlignment="Left" Margin="10" >
-      <TextBlock Text="{loc:Localization BtnCancel}"/>
-    </Button>
-    <Button Command="{Binding Login}" Grid.Row="6" Grid.Column="1" Width="100" Height="30" HorizontalAlignment="Right" Margin="10" IsDefault="True">
-      <TextBlock Text="{loc:Localization BtnOK}"/>
-    </Button>
+    <Panel DockPanel.Dock="Top" Margin="20,40,20,0">
+      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Cancel}" Width="100" Height="30" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnOK}" Command="{Binding Login}" Width="100" Height="30" HorizontalAlignment="Right" IsDefault="True" />
+    </Panel>
     
-  </Grid>
+
+    <!-- Progress indicator -->
+    <ProgressBar DockPanel.Dock="Bottom" Margin="0" IsIndeterminate="False" Value="{Binding Block1Progress}" Maximum="{Binding MaxProgress}"
+                 Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10"/>
+
+  </DockPanel>
+
 </UserControl>

--- a/SQRLDotNetClientUI/Views/AuthenticationView.xaml
+++ b/SQRLDotNetClientUI/Views/AuthenticationView.xaml
@@ -22,7 +22,7 @@
 
     <!-- "Identity button/label -->
     <StackPanel IsVisible="{Binding ShowIdentitySelector}" Orientation="Horizontal" DockPanel.Dock="Top" HorizontalAlignment="Center" Margin="5,5,5,0">
-      <Button Command="{Binding SwitchIdentity}" IsVisible="{Binding SwitchIdentity}" Margin="0,5,0,0" BorderBrush="Transparent">
+      <Button Name="btnIdentitySelector" Command="{Binding SwitchIdentity}" IsVisible="{Binding SwitchIdentity}" Margin="0,5,0,0" BorderBrush="Transparent">
         <Button.Template>
           <ControlTemplate>
             <StackPanel Orientation="Horizontal">
@@ -45,7 +45,7 @@
     </StackPanel>
 
     <!-- "Show advanced functions" button/label -->
-    <Button Command="{Binding ShowAdvancedFunctions}" IsVisible="{Binding !AdvancedFunctionsVisible}" DockPanel.Dock="Top" 
+    <Button Name="btnAdvancedFunctions" Command="{Binding ShowAdvancedFunctions}" IsVisible="{Binding !AdvancedFunctionsVisible}" DockPanel.Dock="Top" 
             HorizontalAlignment="Center" BorderBrush="Transparent">
       <Button.Template>
         <ControlTemplate>
@@ -60,7 +60,7 @@
       <!-- Alt-ID -->  
       <StackPanel Orientation="Horizontal" Margin="20,0,20,0">
         <TextBlock Text="{loc:Localization AltIDLabel}" Width="100" VerticalAlignment="Center" FontSize="14" TextWrapping="Wrap"/>
-        <loc:CopyPasteTextBox Text="{Binding AltID}" HorizontalAlignment="Left" Width="230" Height="30"/>
+        <loc:CopyPasteTextBox Name="txtAltID" Text="{Binding AltID}" HorizontalAlignment="Left" Width="230" Height="30"/>
       </StackPanel>
 
       <!-- Enable/Disable/Remove radio buttons -->

--- a/SQRLDotNetClientUI/Views/AuthenticationView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/AuthenticationView.xaml.cs
@@ -1,21 +1,45 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using SQRLDotNetClientUI.AvaloniaExtensions;
 using SQRLDotNetClientUI.ViewModels;
 
 namespace SQRLDotNetClientUI.Views
 {
     public class AuthenticationView : UserControl
     {
+        private CopyPasteTextBox _txtPassword = null;
+        private CopyPasteTextBox _txtAltID = null;
+
         public AuthenticationView()
         {
             this.InitializeComponent();
-            
+            _txtPassword = this.FindControl<CopyPasteTextBox>("txtPassword");
+            _txtAltID = this.FindControl<CopyPasteTextBox>("txtAltID");
+            this.GotFocus += AuthenticationView_GotFocus;
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        private void AuthenticationView_GotFocus(object sender, Avalonia.Input.GotFocusEventArgs e)
+        {
+            if (e?.Source is Button)
+            {
+                if (((Button)e.Source).Name == "btnIdentitySelector")
+                {
+                    _txtPassword.Focus();
+                    e.Handled = true;
+                }
+
+                if (((Button)e.Source).Name == "btnAdvancedFunctions")
+                {
+                    _txtAltID.Focus();
+                    e.Handled = true;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Issue #36.

**Description**:

This PR enables identity switching in the auth dialog. It also contains a redesign of the auth dialog, hiding stuff like Alt-ID and Disable/Enable/Rekey etc. behind an `Advanced functions` link.

**Notes**:
The Identity switcher will only be shown in the auth dialog if there actually is more than one identity available. Also, if the "advanced functions" are being shown, there is currently no way to hide them again, because I felt it was unnecessary, but this can be discussed of course. The same goes for dynamically changing the auth window size, which I didn't bother with for now, but this can be improved upon later if we want (we might even consider doing the auth in a new window instead of reusing the `MainWindow`.

This is the new auth dialog in action. The second login run shows how to enter an Alt-ID:
(Sorry for the German UI, but now that it's all localized, it's not that easy to get the english UI back. I'll post an issue for setting the language manually later.)

![new_login_flow](https://user-images.githubusercontent.com/4005543/75633206-4164be00-5c03-11ea-96a2-1b9b8fa80215.gif)
