### PR TITLE
Fix InputSecretDialog

### DIFF
--- a/SQRLDotNetClientUI/Views/InputSecretDialogView.xaml
+++ b/SQRLDotNetClientUI/Views/InputSecretDialogView.xaml
@@ -2,6 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+        xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
         xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
         xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
@@ -18,8 +20,12 @@
   <StackPanel Margin="20" Orientation="Vertical">
     <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="20" HorizontalAlignment="Center" Margin="10"></Image>
     <TextBlock Name="lblMessage" TextAlignment="Center" Margin="0,0,10,0">Please enter secret:</TextBlock>
-    <loc:CopyPasteTextBox Name="txtSecret" TextWrapping="NoWrap" Margin="0,10,0,0" Width="250"></loc:CopyPasteTextBox>
-    <Button Name="btnOK" Content="{loc:Localization BtnOK}" Margin="0,15,0,20" Width="120" Height="30" />
+    <loc:CopyPasteTextBox Name="txtSecret" TextWrapping="NoWrap" Margin="0,10,0,0" Width="250">
+      <i:Interaction.Behaviors>
+        <behaviors:FocusOnAttached />
+      </i:Interaction.Behaviors>
+    </loc:CopyPasteTextBox>
+    <Button Name="btnOK" Content="{loc:Localization BtnOK}" IsDefault="True" Margin="0,15,0,20" Width="120" Height="30" />
   </StackPanel>
   
 </Window>

--- a/SQRLDotNetClientUI/Views/InputSecretDialogView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/InputSecretDialogView.xaml.cs
@@ -1,15 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Controls.Primitives;
-using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
-using Avalonia.Platform;
-using ReactiveUI;
 using SQRLDotNetClientUI.AvaloniaExtensions;
-using System;
-using System.ComponentModel;
-using System.Threading.Tasks;
 
 namespace SQRLDotNetClientUI.Views
 {
@@ -44,8 +37,10 @@ namespace SQRLDotNetClientUI.Views
             _btnOK = this.FindControl<Button>("btnOK");
             _lblMessage = this.FindControl<TextBlock>("lblMessage");
 
-            //_txtSecret.KeyUp += _txtSecret_KeyUp;
-            _btnOK.Click += _btnOK_Click;
+            _btnOK.Click += (object sender, RoutedEventArgs e) =>
+            {
+                this.Close(_txtSecret.Text);
+            };
 
             this._secretType = secretType;
             switch (secretType)
@@ -68,34 +63,9 @@ namespace SQRLDotNetClientUI.Views
 #endif
         }
 
-        private void _btnOK_Click(object sender, RoutedEventArgs e)
-        {
-            this.Close(_txtSecret.Text);
-        }
-
-        private void _txtSecret_KeyUp(object sender, KeyEventArgs e)
-        {
-            if (e.Key != Key.Return) return;
-
-            RoutedEventArgs click = new RoutedEventArgs
-            {
-                Source = _txtSecret,
-                RoutedEvent = Button.ClickEvent
-            };
-
-            _btnOK.RaiseEvent(click);
-            e.Handled = true;
-        }
-
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
-        }
-
-        protected override void OnOpened(EventArgs e)
-        {
-            base.OnOpened(e);
-            Application.Current.FocusManager.Focus(_txtSecret);
         }
     }
 


### PR DESCRIPTION
This is just a quick fix for the regression that was introduced in the `InputSecretDialogView`.

Please note that this does **NOT** handle the input focus bug that is seemingly being caused by the `MessageBox.Avalonia` package that we are using.