### PR TITLE
Fix import not honoring identity settings

### DIFF
--- a/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
@@ -92,20 +92,15 @@ namespace SQRLDotNetClientUI.ViewModels
 
             if (ok)
             {
-                SQRLIdentity newId = new SQRLIdentity();
+                SQRLIdentity newId = this.Identity.Clone();
                 byte[] imk = SQRL.CreateIMK(iuk);
 
-                if (this.Identity.HasBlock(0)) newId.Blocks.Add(this.Identity.Block0);
-                else SQRL.GenerateIdentityBlock0(imk, newId);
+                if (!newId.HasBlock(0)) SQRL.GenerateIdentityBlock0(imk, newId);
                 var block1 = SQRL.GenerateIdentityBlock1(iuk, this.NewPassword, newId, progressBlock1);
                 var block2 = SQRL.GenerateIdentityBlock2(iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
                 await Task.WhenAll(block1, block2);
+                if (newId.HasBlock(3)) SQRL.GenerateIdentityBlock3(iuk, this.Identity, newId, imk, imk); 
 
-                newId = block2.Result;
-                if (this.Identity.Block3 != null)
-                {
-                    SQRL.GenerateIdentityBlock3(iuk, this.Identity, newId, imk, imk); 
-                }
                 newId.IdentityName = this.IdentityName;
 
                 try

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -463,7 +463,6 @@ namespace SQRLUtilsLib
             var identityT = await Task.Run(() =>
             {
                 identity.Block2.RandomSalt = randomSalt;
-
                 identity.Block2.IterationCount = (uint)key.Key;
 
                 List<byte> plainText = new List<byte>();
@@ -1476,9 +1475,9 @@ namespace SQRLUtilsLib
             List<byte> unencryptedOldKeys = new List<byte>();
             unencryptedOldKeys.AddRange(oldIuk);
             int skip = 0;
+
             if (oldIdentity.HasBlock(3) && oldIdentity.Block3.EncryptedPrevIUKs.Count > 0)
             {
-                
                 decryptedBlock3 = DecryptBlock3(oldImk, oldIdentity, out bool allGood);
                 if (allGood)
                 {


### PR DESCRIPTION
Issue #49.

### Description:
Fix a bug where we would not retain any identity plaintext settings upon importing an identity. I fixed this by cloning the imported identity before running it through the re-encryption instead if starting from a blank identity.