### PR TITLE
Replace tuples with specialized classes

### DIFF
--- a/SQRLConsoleTester/Program.cs
+++ b/SQRLConsoleTester/Program.cs
@@ -33,8 +33,8 @@ namespace SQRLConsoleTester
             bool run =true;
             
            
-            var decryptedData = await SQRL.DecryptBlock1(newId, "Zingo-Bingo-Slingo-Dingo", progress);
-            if (decryptedData.Item1)
+            var block1Keys = await SQRL.DecryptBlock1(newId, "Zingo-Bingo-Slingo-Dingo", progress);
+            if (block1Keys.DecryptionSucceeded)
             {
                 try
                 {
@@ -46,11 +46,11 @@ namespace SQRLConsoleTester
                         string AltID = "";
 
 
-                        var siteKvp = SQRL.CreateSiteKey(requestURI, AltID, decryptedData.Item2);
+                        var siteKvp = SQRL.CreateSiteKey(requestURI, AltID, block1Keys.Imk);
                         Dictionary<byte[],Tuple<byte[],KeyPair>> priorKvps = null;
                         if(newId.Block3!=null && newId.Block3.Edition>0)
                         {
-                            byte[] decryptedBlock3 = SQRL.DecryptBlock3(decryptedData.Item2, newId, out bool allGood);
+                            byte[] decryptedBlock3 = SQRL.DecryptBlock3(block1Keys.Imk, newId, out bool allGood);
                             List<byte[]> oldIUKs = new List<byte[]>();
                             if(allGood)
                             {
@@ -84,31 +84,36 @@ namespace SQRLConsoleTester
                                 if(!string.IsNullOrEmpty(serverRespose.SIN))
                                 {
                                     additionalData = new StringBuilder();
-                                    byte[] ids = SQRL.CreateIndexedSecret(requestURI, AltID, decryptedData.Item2, Encoding.UTF8.GetBytes(serverRespose.SIN));
+                                    byte[] ids = SQRL.CreateIndexedSecret(requestURI, AltID, block1Keys.Imk, 
+                                        Encoding.UTF8.GetBytes(serverRespose.SIN));
                                     additionalData.AppendLineWindows($"ins={Sodium.Utilities.BinaryToBase64(ids, Utilities.Base64Variant.UrlSafeNoPadding)}");
                                 }
                                 Console.WriteLine("The site doesn't recognize this ID, would you like to proceed and create one? (Y/N)");
                                 if (Console.ReadLine().StartsWith("Y", StringComparison.OrdinalIgnoreCase))
                                 {
-                                    serverRespose = SQRL.GenerateNewIdentCommand(serverRespose.NewNutURL, siteKvp, serverRespose.FullServerRequest, decryptedData.Item3, opts, additionalData);
+                                    serverRespose = SQRL.GenerateNewIdentCommand(serverRespose.NewNutURL, siteKvp, 
+                                        serverRespose.FullServerRequest, block1Keys.Ilk, opts, additionalData);
                                 }
                             }
                             else if(serverRespose.PreviousIDMatch)
                             {
-                                
                                 byte[] ursKey = null;
-                                ursKey = SQRL.GetURSKey(serverRespose.PriorMatchedKey.Key, Sodium.Utilities.Base64ToBinary(serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
+                                ursKey = SQRL.GetURSKey(serverRespose.PriorMatchedKey.Key, Sodium.Utilities.Base64ToBinary(
+                                    serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
+
                                 StringBuilder additionalData = null;
                                 if (!string.IsNullOrEmpty(serverRespose.SIN))
                                 {
                                     additionalData = new StringBuilder();
-                                    byte[] ids = SQRL.CreateIndexedSecret(requestURI, AltID, decryptedData.Item2, Encoding.UTF8.GetBytes(serverRespose.SIN));
+                                    byte[] ids = SQRL.CreateIndexedSecret(requestURI, AltID, block1Keys.Imk, Encoding.UTF8.GetBytes(serverRespose.SIN));
                                     additionalData.AppendLineWindows($"ins={Sodium.Utilities.BinaryToBase64(ids, Utilities.Base64Variant.UrlSafeNoPadding)}");
                                     byte[] pids = SQRL.CreateIndexedSecret(serverRespose.PriorMatchedKey.Value.Item1, Encoding.UTF8.GetBytes(serverRespose.SIN));
                                     additionalData.AppendLineWindows($"pins={Sodium.Utilities.BinaryToBase64(pids, Utilities.Base64Variant.UrlSafeNoPadding)}");
                                     
                                 }
-                                serverRespose = SQRL.GenerateIdentCommandWithReplace(serverRespose.NewNutURL, siteKvp, serverRespose.FullServerRequest, decryptedData.Item3,ursKey,serverRespose.PriorMatchedKey.Value.Item2,opts, additionalData);
+                                serverRespose = SQRL.GenerateIdentCommandWithReplace(
+                                    serverRespose.NewNutURL, siteKvp, serverRespose.FullServerRequest, block1Keys.Ilk, 
+                                    ursKey,serverRespose.PriorMatchedKey.Value.Item2,opts, additionalData);
                             }
                             else if (serverRespose.CurrentIDMatch)
                             {
@@ -152,12 +157,12 @@ namespace SQRLConsoleTester
                                             Console.WriteLine($"Decrypting with Rescue Code: {percent.Key}%");
                                         });
                                         var iukData = await SQRL.DecryptBlock2(newId, rescueCode, progress);
-                                        if (iukData.Item1)
+                                        if (iukData.DecryptionSucceeded)
                                         {
                                             byte[] ursKey = null;
-                                            ursKey = SQRL.GetURSKey(iukData.Item2, Sodium.Utilities.Base64ToBinary(serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
+                                            ursKey = SQRL.GetURSKey(iukData.Iuk, Sodium.Utilities.Base64ToBinary(serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
                                             
-                                            iukData.Item2.ZeroFill();
+                                            iukData.Iuk.ZeroFill();
                                             serverRespose = SQRL.GenerateEnableCommand(serverRespose.NewNutURL, siteKvp,serverRespose.FullServerRequest, ursKey,addClientData, opts);
                                         }
                                         else
@@ -214,10 +219,10 @@ namespace SQRLConsoleTester
                                                 Console.WriteLine($"Decrypting with Rescue Code: {percent.Key}%");
                                             });
                                             var iukData = await SQRL.DecryptBlock2(newId, rescueCode);
-                                            if (iukData.Item1)
+                                            if (iukData.DecryptionSucceeded)
                                             {
-                                                byte[] ursKey = SQRL.GetURSKey(iukData.Item2, Sodium.Utilities.Base64ToBinary(serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
-                                                iukData.Item2.ZeroFill();
+                                                byte[] ursKey = SQRL.GetURSKey(iukData.Iuk, Sodium.Utilities.Base64ToBinary(serverRespose.SUK, string.Empty, Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
+                                                iukData.Iuk.ZeroFill();
                                                 serverRespose = SQRL.GenerateSQRLCommand(SQRLCommands.remove, serverRespose.NewNutURL, siteKvp, serverRespose.FullServerRequest, addClientData, opts,null,ursKey);
                                                 if (sqrl.cps != null && sqrl.cps.PendingResponse)
                                                 {

--- a/SQRLConsoleTester/Program.cs
+++ b/SQRLConsoleTester/Program.cs
@@ -47,7 +47,7 @@ namespace SQRLConsoleTester
 
 
                         var siteKvp = SQRL.CreateSiteKey(requestURI, AltID, block1Keys.Imk);
-                        Dictionary<byte[],Tuple<byte[],KeyPair>> priorKvps = null;
+                        Dictionary<byte[], PriorSiteKeysResult> priorSiteKeys = null;
                         if(newId.Block3!=null && newId.Block3.Edition>0)
                         {
                             byte[] decryptedBlock3 = SQRL.DecryptBlock3(block1Keys.Imk, newId, out bool allGood);
@@ -66,14 +66,14 @@ namespace SQRLConsoleTester
                                 }
                                 
                                 SQRL.ZeroFillByteArray(ref decryptedBlock3);
-                                priorKvps= SQRL.CreatePriorSiteKeys(oldIUKs, requestURI, AltID);
+                                priorSiteKeys= SQRL.CreatePriorSiteKeys(oldIUKs, requestURI, AltID);
                                 oldIUKs.Clear();
                             }
                         }
 
                         //SQRL.ZeroFillByteArray(ref decryptedData.Item2);
                         //decryptedData.Item2.ZeroFill();
-                        var serverRespose = SQRL.GenerateQueryCommand(requestURI, siteKvp, opts,null,0, priorKvps);
+                        var serverRespose = SQRL.GenerateQueryCommand(requestURI, siteKvp, opts, null, 0, priorSiteKeys);
                         
                         if (!serverRespose.CommandFailed)
                         {
@@ -107,13 +107,13 @@ namespace SQRLConsoleTester
                                     additionalData = new StringBuilder();
                                     byte[] ids = SQRL.CreateIndexedSecret(requestURI, AltID, block1Keys.Imk, Encoding.UTF8.GetBytes(serverRespose.SIN));
                                     additionalData.AppendLineWindows($"ins={Sodium.Utilities.BinaryToBase64(ids, Utilities.Base64Variant.UrlSafeNoPadding)}");
-                                    byte[] pids = SQRL.CreateIndexedSecret(serverRespose.PriorMatchedKey.Value.Item1, Encoding.UTF8.GetBytes(serverRespose.SIN));
+                                    byte[] pids = SQRL.CreateIndexedSecret(serverRespose.PriorMatchedKey.Value.SiteSeed, Encoding.UTF8.GetBytes(serverRespose.SIN));
                                     additionalData.AppendLineWindows($"pins={Sodium.Utilities.BinaryToBase64(pids, Utilities.Base64Variant.UrlSafeNoPadding)}");
                                     
                                 }
                                 serverRespose = SQRL.GenerateIdentCommandWithReplace(
                                     serverRespose.NewNutURL, siteKvp, serverRespose.FullServerRequest, block1Keys.Ilk, 
-                                    ursKey,serverRespose.PriorMatchedKey.Value.Item2,opts, additionalData);
+                                    ursKey, serverRespose.PriorMatchedKey.Value.KeyPair, opts, additionalData);
                             }
                             else if (serverRespose.CurrentIDMatch)
                             {

--- a/SQRLDotNetClientUI/Models/QuickPassManager.cs
+++ b/SQRLDotNetClientUI/Models/QuickPassManager.cs
@@ -235,7 +235,7 @@ namespace SQRLDotNetClientUI.Models
 
             string quickPass = password.Substring(0, qpi.QuickPassLength);
 
-            KeyValuePair<int, byte[]> enscryptResult = await SQRL.EnScryptTime(
+            var enScryptResult = await SQRL.EnScryptTime(
                 quickPass, 
                 qpi.ScryptRandomSalt, 
                 (int)Math.Pow(2, 9), 
@@ -243,9 +243,9 @@ namespace SQRLDotNetClientUI.Models
                 progress, 
                 progressText);
 
-            qpi.ScryptIterationCount = enscryptResult.Key;
-            qpi.EncryptedImk = StreamEncryption.Encrypt(imk, qpi.Nonce, enscryptResult.Value);
-            qpi.EncryptedIlk = StreamEncryption.Encrypt(ilk, qpi.Nonce, enscryptResult.Value);
+            qpi.ScryptIterationCount = enScryptResult.IterationCount;
+            qpi.EncryptedImk = StreamEncryption.Encrypt(imk, qpi.Nonce, enScryptResult.Key);
+            qpi.EncryptedIlk = StreamEncryption.Encrypt(ilk, qpi.Nonce, enScryptResult.Key);
 
             // If we already have a QuickPass entry for this identity, remove it first
             if (HasQuickPass(qpi.IdentityUniqueId)) 

--- a/SQRLDotNetClientUI/Platform/OSX/NotifyIcon.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/NotifyIcon.cs
@@ -26,9 +26,11 @@ namespace SQRLDotNetClientUI.Platform.OSX
             }
         }
 
+        #pragma warning disable 67 // Get rid of event "not used" warnings
         public event EventHandler<EventArgs> Click;
         public event EventHandler<EventArgs> DoubleClick;
         public event EventHandler<EventArgs> RightClick;
+        #pragma warning restore 67
 
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
@@ -81,9 +81,9 @@ namespace SQRLDotNetClientUI.ViewModels
                 this.ProgressText = p.Value + p.Key;
             });
 
-            (bool ok, byte[] imk, byte[] ilk) = await SQRL.DecryptBlock1(Identity, password, progress);
+            var block1Keys = await SQRL.DecryptBlock1(Identity, password, progress);
 
-            if (!ok)
+            if (!block1Keys.DecryptionSucceeded)
             {
 
                 await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
@@ -96,8 +96,8 @@ namespace SQRLDotNetClientUI.ViewModels
                 return;
             }
 
-            SQRLIdentity id = await SQRL.GenerateIdentityBlock1(
-                imk, ilk, password, IdentityCopy, progress, IdentityCopy.Block1.PwdVerifySeconds);
+            SQRLIdentity id = await SQRL.GenerateIdentityBlock1(block1Keys.Imk, block1Keys.Ilk, 
+                password, IdentityCopy, progress, IdentityCopy.Block1.PwdVerifySeconds);
 
             // Swap out the old type 1 block with the updated one
             // TODO: We should probably make sure that this is an atomic operation

--- a/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
@@ -87,19 +87,19 @@ namespace SQRLDotNetClientUI.ViewModels
                 this.Block2DecryptProgressPercentage = ((int)percent.Key);
             });
 
-            (bool ok, byte[] iuk, string errorMsg) = await SQRL.DecryptBlock2(
+            var iukData = await SQRL.DecryptBlock2(
                 this.Identity, SQRL.CleanUpRescueCode(this.RescueCode), progressDecryptBlock2);
 
-            if (ok)
+            if (iukData.DecryptionSucceeded)
             {
                 SQRLIdentity newId = this.Identity.Clone();
-                byte[] imk = SQRL.CreateIMK(iuk);
+                byte[] imk = SQRL.CreateIMK(iukData.Iuk);
 
                 if (!newId.HasBlock(0)) SQRL.GenerateIdentityBlock0(imk, newId);
-                var block1 = SQRL.GenerateIdentityBlock1(iuk, this.NewPassword, newId, progressBlock1);
-                var block2 = SQRL.GenerateIdentityBlock2(iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
+                var block1 = SQRL.GenerateIdentityBlock1(iukData.Iuk, this.NewPassword, newId, progressBlock1);
+                var block2 = SQRL.GenerateIdentityBlock2(iukData.Iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
                 await Task.WhenAll(block1, block2);
-                if (newId.HasBlock(3)) SQRL.GenerateIdentityBlock3(iuk, this.Identity, newId, imk, imk); 
+                if (newId.HasBlock(3)) SQRL.GenerateIdentityBlock3(iukData.Iuk, this.Identity, newId, imk, imk); 
 
                 newId.IdentityName = this.IdentityName;
 
@@ -109,10 +109,10 @@ namespace SQRLDotNetClientUI.ViewModels
                 }
                 catch (InvalidOperationException e)
                 {
-                    var btnRsult = await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                              e.Message, 
-                                                              MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                                              .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                    var btnRsult = await new Views.MessageBox(
+                        _loc.GetLocalizationValue("ErrorTitleGeneric"), e.Message,
+                        MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                        .ShowDialog<MessagBoxDialogResult>(_mainWindow);
                 }
                 finally
                 {
@@ -122,11 +122,11 @@ namespace SQRLDotNetClientUI.ViewModels
             }
             else
             {
-                
-                var btnRsult = await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                          _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
-                                                          MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                                          .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                var btnRsult = await new Views.MessageBox(
+                    _loc.GetLocalizationValue("ErrorTitleGeneric"),
+                    _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
+                    MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
             }
         }
     }

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -157,12 +157,10 @@ namespace SQRLDotNetClientUI.ViewModels
             }
         }
 
-        public async void RekeyIdentity()
+        public void RekeyIdentity()
         {
 
-
             //TODO: Implement this
-
 
         }
     }

--- a/SQRLDotNetClientUI/ViewModels/NewIdentityVerifyViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/NewIdentityVerifyViewModel.cs
@@ -67,21 +67,19 @@ namespace SQRLDotNetClientUI.ViewModels
                 this.Block2ProgressPercentage = ((int)percent.Key);
             });
 
-            var data = SQRL.DecryptBlock1(this.Identity, this.Password, progressBlock1);
-            var dataBlock2 = SQRL.DecryptBlock2(this.Identity, SQRL.CleanUpRescueCode(this.RescueCode), progressBlock2);
-            await Task.WhenAll(data, dataBlock2);
+            var block1Task = SQRL.DecryptBlock1(this.Identity, this.Password, progressBlock1);
+            var block2Task = SQRL.DecryptBlock2(this.Identity, SQRL.CleanUpRescueCode(this.RescueCode), progressBlock2);
+            await Task.WhenAll(block1Task, block2Task);
 
             string msg = "";
-            if (!data.Result.Item1) msg = _loc.GetLocalizationValue("InvalidPasswordMessage") + Environment.NewLine;
-            if (!dataBlock2.Result.Item1) msg = _loc.GetLocalizationValue("InvalidRescueCodeMessage") + Environment.NewLine;
+            if (!block1Task.Result.DecryptionSucceeded) msg = _loc.GetLocalizationValue("InvalidPasswordMessage") + Environment.NewLine;
+            if (!block2Task.Result.DecryptionSucceeded) msg = _loc.GetLocalizationValue("InvalidRescueCodeMessage") + Environment.NewLine;
 
             if (!string.IsNullOrEmpty(msg))
             {
-                
-                await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                            $"{msg}", 
-                                            MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                            .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"), $"{msg}", 
+                    MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
             }
             else
             {
@@ -91,11 +89,10 @@ namespace SQRLDotNetClientUI.ViewModels
                 }
                 catch (InvalidOperationException e)
                 {
-
                     await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                e.Message, MessageBoxSize.Medium,
-                                                MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                                .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                        e.Message, MessageBoxSize.Medium,
+                        MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                        .ShowDialog<MessagBoxDialogResult>(_mainWindow);
                 }
                 finally
                 {

--- a/SQRLUtilLibTest/SQRLCryptoTests.cs
+++ b/SQRLUtilLibTest/SQRLCryptoTests.cs
@@ -127,8 +127,8 @@ namespace SQRLUtilLibTest
                 byte[] imk = SQRL.CreateIMK(iuk);
                 byte[] ilk = SQRL.CreateILK(iuk);
                 var decryptedData = await SQRL.DecryptBlock1(identity, password);
-                Assert.Equal(Sodium.Utilities.BinaryToHex(imk), Sodium.Utilities.BinaryToHex(decryptedData.Item2));
-                Assert.Equal(Sodium.Utilities.BinaryToHex(ilk), Sodium.Utilities.BinaryToHex(decryptedData.Item3));
+                Assert.Equal(Sodium.Utilities.BinaryToHex(imk), Sodium.Utilities.BinaryToHex(decryptedData.Imk));
+                Assert.Equal(Sodium.Utilities.BinaryToHex(ilk), Sodium.Utilities.BinaryToHex(decryptedData.Ilk));
             }
         }
 
@@ -143,8 +143,8 @@ namespace SQRLUtilLibTest
                 string rescueCode = SQRL.CreateRescueCode();
                 identity= await SQRL.GenerateIdentityBlock2(iuk, rescueCode, identity);
 
-                var t = await SQRL.DecryptBlock2(identity, rescueCode);
-                Assert.Equal(Sodium.Utilities.BinaryToHex(iuk), Sodium.Utilities.BinaryToHex(t.Item2));
+                var decryptResult = await SQRL.DecryptBlock2(identity, rescueCode);
+                Assert.Equal(Sodium.Utilities.BinaryToHex(iuk), Sodium.Utilities.BinaryToHex(decryptResult.Iuk));
             }
         }
 

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -230,9 +230,9 @@ namespace SQRLUtilsLib
         }
 
         /// <summary>
-        /// Run the "Scrypt" memory hard key derivation function on the given 
-        /// password for a determined amount of time, using the given random 
-        /// salt and logNFactor.
+        /// Run the "Scrypt" memory hard key derivation function on the given <paramref name="password"/> 
+        /// for a determined amount of <paramref name="secondsToRun"/>, using the given <paramref name="randomSalt"/> 
+        /// and <paramref name="logNFactor"/>.
         /// </summary>
         /// <param name="password">The password to hash.</param>
         /// <param name="randomSalt">Random data which is being used as salt for Scrypt.</param>
@@ -240,7 +240,8 @@ namespace SQRLUtilsLib
         /// <param name="secondsToRun">Amount of time to run Scrypt (determines iteration count).</param>
         /// <param name="progress">An object implementing the IProgress interface for tracking the operation's progress (optional).</param>
         /// <param name="progressText">A string representing a text descrition for the progress indicator (optional).</param>
-        public static async Task<KeyValuePair<int, byte[]>> EnScryptTime(String password, byte[] randomSalt, int logNFactor, int secondsToRun, IProgress<KeyValuePair<int, string>> progress = null, string progressText = null)
+        public static async Task<EnScryptTimeResult> EnScryptTime(String password, byte[] randomSalt, int logNFactor, int secondsToRun, 
+            IProgress<KeyValuePair<int, string>> progress = null, string progressText = null)
         {
             if (!SodiumInitialized)
                 SodiumInit();
@@ -249,7 +250,8 @@ namespace SQRLUtilsLib
             DateTime startTime = DateTime.Now;
             byte[] xorKey = new byte[32];
             int count = 0;
-            var kvp =await Task.Run(() =>
+
+            return await Task.Run(() =>
             {
                 count = 0;
                 while (Math.Abs((DateTime.Now - startTime).TotalSeconds) < secondsToRun)
@@ -281,10 +283,8 @@ namespace SQRLUtilsLib
                     }
                     count++;
                 }
-                return new KeyValuePair<int, byte[]>(count, xorKey);
+                return new EnScryptTimeResult(count, xorKey);
             });
-
-            return kvp;
         }
 
         /// <summary>
@@ -1713,6 +1713,29 @@ namespace SQRLUtilsLib
         {
             this.SignatureType = signatureType;
             this.Signature = signature;
+        }
+    }
+
+    /// <summary>
+    /// Represents the results of a "timed" EnScrypt PBKDF operation.
+    /// </summary>
+    public class EnScryptTimeResult
+    {
+        /// <summary>
+        /// The scrypt iteration count that was determined by running the 
+        /// scrypt function for the specified amount of time.
+        /// </summary>
+        public int IterationCount;
+
+        /// <summary>
+        /// The key that was derived by running the input trough the EnScrypt PBKDF.
+        /// </summary>
+        public byte[] Key;
+
+        public EnScryptTimeResult(int iterationCount, byte[] key)
+        {
+            this.IterationCount = iterationCount;
+            this.Key = key;
         }
     }
 }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1262,23 +1262,25 @@ namespace SQRLUtilsLib
         }
 
         /// <summary>
-        /// Generates a signature with the provided signatureID (urs, ids, pids... etc.)
-        /// for the given <c>server</c> and <c>client</c> parameter values, signed by the given key.
+        /// Generates a signature with the provided <paramref name="signatureID"/> (urs, ids, pids... etc.)
+        /// for the given <paramref name="encodedServer"/> and <paramref name="client"/> parameter values, 
+        /// signed by the given <paramref name="key"/>.
         /// </summary>
         /// <param name="signatureID">The type of the signature to be created (urs, ids, pids... etc.).</param>
         /// <param name="encodedServer">The base64_url-encoded contents for the server parameter.</param>
         /// <param name="client">The unencoded contents for the client parameter.</param>
         /// <param name="key">The private key for signing the message.</param>
-        /// <returns>Returns a <c>KeyValuePair</c>, where the key is the chosen signature id (urs, ids, pids... etc.), 
-        /// and the value is the generated, base64_url-encoded signature.</returns>
-        public static KeyValuePair<string,string> GenerateSignature(string signatureID, string encodedServer, string client, byte[] key)
+        /// <returns>Returns a <c>SignatureResult</c> object containing the chosen signature id (urs, ids, pids... etc.)
+        /// and the base64_url-encoded signature.</returns>
+        public static SignatureResult GenerateSignature(string signatureID, string encodedServer, string client, byte[] key)
         {
-            string encodedClient = Sodium.Utilities.BinaryToBase64(Encoding.UTF8.GetBytes(client.ToString()), Utilities.Base64Variant.UrlSafeNoPadding);
+            string encodedClient = Sodium.Utilities.BinaryToBase64(
+                Encoding.UTF8.GetBytes(client.ToString()), Utilities.Base64Variant.UrlSafeNoPadding);
             
             byte[] signature = Sodium.PublicKeyAuth.SignDetached(Encoding.UTF8.GetBytes(encodedClient + encodedServer), key);
             string encodedSignature = Sodium.Utilities.BinaryToBase64(signature, Utilities.Base64Variant.UrlSafeNoPadding);
 
-            return new KeyValuePair<string, string>(signatureID, encodedSignature);
+            return new SignatureResult(signatureID, encodedSignature);
         }
 
         /// <summary>
@@ -1689,6 +1691,28 @@ namespace SQRLUtilsLib
         {
             this.Suk = suk;
             this.Vuk = vuk;
+        }
+    }
+
+    /// <summary>
+    /// Represents the results of creting a SQRL protocol signature.
+    /// </summary>
+    public class SignatureResult
+    {
+        /// <summary>
+        /// The type of the signature to be created (urs, ids, pids... etc.).
+        /// </summary>
+        public string SignatureType;
+
+        /// <summary>
+        /// The Base64URL-encoded signature.
+        /// </summary>
+        public string Signature;
+
+        public SignatureResult(string signatureType, string signature)
+        {
+            this.SignatureType = signatureType;
+            this.Signature = signature;
         }
     }
 }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -172,7 +172,7 @@ namespace SQRLUtilsLib
         /// derived from the given Identity Lock Key (ILK).
         /// </summary>
         /// <param name="ILK">The identity's Identity Lock Key (ILK).</param>
-        public static KeyValuePair<byte[], byte[]> GetSukVuk(byte[] ILK)
+        public static SukVukResult GetSukVuk(byte[] ILK)
         {
             if (!SodiumInitialized)
                 SodiumInit();
@@ -181,12 +181,10 @@ namespace SQRLUtilsLib
             var SUK = Sodium.ScalarMult.Base(RLK);
 
             var bytesToSign = Sodium.ScalarMult.Mult(RLK, ILK);
-
             var vukKeyPair = Sodium.PublicKeyAuth.GenerateKeyPair(bytesToSign);
-
             var VUK = vukKeyPair.PublicKey;
 
-            return KeyValuePair.Create(SUK, VUK);
+            return new SukVukResult(SUK, VUK);
         }
 
         /// <summary>
@@ -1668,6 +1666,29 @@ namespace SQRLUtilsLib
         {
             this.NewRescueCode = newRescueCode;
             this.RekeyedIdentity= rekeyedIdentity;
+        }
+    }
+
+    /// <summary>
+    /// Represents the results of creting a Server Unlock Key (SUK) / 
+    /// Verification Unlock Key (VUK) key pair.
+    /// </summary>
+    public class SukVukResult
+    {
+        /// <summary>
+        /// The generated Server Unlock Key (SUK).
+        /// </summary>
+        public byte[] Suk;
+
+        /// <summary>
+        /// The generted Verification Unlock Key (VUK).
+        /// </summary>
+        public byte[] Vuk;
+
+        public SukVukResult(byte[] suk, byte[] vuk)
+        {
+            this.Suk = suk;
+            this.Vuk = vuk;
         }
     }
 }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1119,7 +1119,7 @@ namespace SQRLUtilsLib
         /// <param name="opts">Optional SQRL options to be appended to the client message.</param>
         /// <param name="sin">Optional base64_url-encoded Secret Index (SIN) parameter to be appended to the client message.</param>
         /// <returns>Returns a <c>SQRLServerResponse</c> object representing the server's response details.</returns>
-        public static SQRLServerResponse GenerateIdentCommandWithReplace(Uri sqrl, KeyPair siteKP, string encodedServerMessage, byte[] ilk,byte[] ursKey, KeyPair priorKey, SQRLOptions opts = null, StringBuilder sin=null)
+        public static SQRLServerResponse GenerateIdentCommandWithReplace(Uri sqrl, KeyPair siteKP, string encodedServerMessage, byte[] ilk, byte[] ursKey, KeyPair priorKey, SQRLOptions opts = null, StringBuilder sin=null)
         {
             var sukvuk = GetSukVuk(ilk);
             StringBuilder addClientData = new StringBuilder();

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -895,15 +895,18 @@ namespace SQRLUtilsLib
         /// <param name="oldIUKs">The list of previous Identity Unlock Keys (IUKs).</param>
         /// <param name="domain">The domain for which to generate the key pairs.</param>
         /// <param name="altID">The "Alternate Id" that should be used for the keypair generation.</param>
-        /// <returns>Returns a <c>Tuple</c> containing the PIUK as the first element and another <c>Tuple</c>
-        /// as the second element, which in turn contains the site seed as the first element as well as the 
-        /// actual ECDH public-private key pair as the second element.</returns>
-        public static Dictionary<byte[], Tuple<byte[],Sodium.KeyPair>> CreatePriorSiteKeys(List<byte[]> oldIUKs, Uri domain, String altID)
+        /// <returns>Returns a <c>Dictionary</c> where the key represents the PIUK and the value contains an object
+        /// encapsulating the site seed as well as the actual ECDH public-private key pair for that particular PIUK.</returns>
+        public static Dictionary<byte[], PriorSiteKeysResult> CreatePriorSiteKeys(List<byte[]> oldIUKs, Uri domain, String altID)
         {
-            Dictionary<byte[], Tuple<byte[],Sodium.KeyPair>> priorSiteKeys = new Dictionary<byte[], Tuple<byte[], Sodium.KeyPair>>();
+            Dictionary<byte[], PriorSiteKeysResult> priorSiteKeys = new Dictionary<byte[], PriorSiteKeysResult>();
             foreach(var oldIUK in oldIUKs)
             {
-                priorSiteKeys.Add(oldIUK,new Tuple<byte[], Sodium.KeyPair>(CreateSiteSeed(domain,altID,CreateIMK(oldIUK)), CreateSiteKey(domain, altID, CreateIMK(oldIUK))));
+                PriorSiteKeysResult result = new PriorSiteKeysResult(
+                    CreateSiteSeed(domain, altID, CreateIMK(oldIUK)),
+                    CreateSiteKey(domain, altID, CreateIMK(oldIUK)));
+
+                priorSiteKeys.Add(oldIUK, result);
             }
 
             return priorSiteKeys;
@@ -1617,6 +1620,29 @@ namespace SQRLUtilsLib
             this.DecryptionSucceeded = operationSucceeded;
             this.Iuk = iuk;
             this.ErrorMessage = errorMessage;
+        }
+    }
+
+    /// <summary>
+    /// Represents the results of creating a prior site key pair.
+    /// </summary>
+    public class PriorSiteKeysResult
+    {
+        /// <summary>
+        /// A binary value created using the site's domain/URL which 
+        /// is used as a seed for a number of cryptographic functions.
+        /// </summary>
+        public byte[] SiteSeed;
+
+        /// <summary>
+        /// The ECDH public-private key pair for a particular site/PIUK.
+        /// </summary>
+        public Sodium.KeyPair KeyPair;
+
+        public PriorSiteKeysResult(byte[] siteSeed, Sodium.KeyPair keyPair)
+        {
+            this.SiteSeed = siteSeed;
+            this.KeyPair = keyPair;
         }
     }
 }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1451,8 +1451,8 @@ namespace SQRLUtilsLib
         /// <param name="rescueCode">The rescue code for the given identity.</param>
         /// <param name="newPassword">The new master password for the rekeyed identity.</param>
         /// <param name="progress">An object implementing the IProgress interface for tracking the operation's progress (optional).</param>
-        /// <returns>Returns a <c>KeyValuePair</c>, where the key is the newly generated rescue code and the value is the rekeyed <c>SQRLIdentity</c>.</returns>
-        public static async Task<KeyValuePair<string,SQRLIdentity>> RekeyIdentity(SQRLIdentity identity, string rescueCode, string newPassword, IProgress<KeyValuePair<int,string>> progress)
+        /// <returns>Returns a <c>RekeyIdentityResult</c> object containingthe newly generated rescue code and the rekeyed <c>SQRLIdentity</c>.</returns>
+        public static async Task<RekeyIdentityResult> RekeyIdentity(SQRLIdentity identity, string rescueCode, string newPassword, IProgress<KeyValuePair<int,string>> progress)
         {
             SQRLIdentity newID = new SQRLIdentity();
             var oldIukData = await SQRL.DecryptBlock2(identity, rescueCode, progress);
@@ -1465,7 +1465,7 @@ namespace SQRLUtilsLib
                 newID= await GenerateIdentityBlock2(newIUK, newRescueCode, newID, progress);
                 GenerateIdentityBlock3(oldIukData.Iuk, identity, newID, CreateIMK(oldIukData.Iuk), CreateIMK(newIUK));
             }
-            return new KeyValuePair<string, SQRLIdentity>(newRescueCode,newID);
+            return new RekeyIdentityResult(newRescueCode, newID);
         }
 
         /// <summary>
@@ -1646,6 +1646,28 @@ namespace SQRLUtilsLib
         {
             this.SiteSeed = siteSeed;
             this.KeyPair = keyPair;
+        }
+    }
+
+    /// <summary>
+    /// Represents the results of rekeying an identity.
+    /// </summary>
+    public class RekeyIdentityResult
+    {
+        /// <summary>
+        /// The rescue code for the new, rekeyed identity.
+        /// </summary>
+        public string NewRescueCode;
+
+        /// <summary>
+        /// The new, rekeyed identity.
+        /// </summary>
+        public SQRLIdentity RekeyedIdentity;
+
+        public RekeyIdentityResult(string newRescueCode, SQRLIdentity rekeyedIdentity)
+        {
+            this.NewRescueCode = newRescueCode;
+            this.RekeyedIdentity= rekeyedIdentity;
         }
     }
 }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1099,8 +1099,8 @@ namespace SQRLUtilsLib
         {
             var sukvuk = GetSukVuk(ilk);
             StringBuilder addClientData = new StringBuilder();
-            addClientData.AppendLineWindows($"suk={Sodium.Utilities.BinaryToBase64(sukvuk.Key, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
-            addClientData.AppendLineWindows($"vuk={Sodium.Utilities.BinaryToBase64(sukvuk.Value, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
+            addClientData.AppendLineWindows($"suk={Sodium.Utilities.BinaryToBase64(sukvuk.Suk, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
+            addClientData.AppendLineWindows($"vuk={Sodium.Utilities.BinaryToBase64(sukvuk.Vuk, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
             if (sin != null)
                 addClientData.Append(sin);
 
@@ -1123,8 +1123,8 @@ namespace SQRLUtilsLib
         {
             var sukvuk = GetSukVuk(ilk);
             StringBuilder addClientData = new StringBuilder();
-            addClientData.AppendLineWindows($"suk={Sodium.Utilities.BinaryToBase64(sukvuk.Key, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
-            addClientData.AppendLineWindows($"vuk={Sodium.Utilities.BinaryToBase64(sukvuk.Value, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
+            addClientData.AppendLineWindows($"suk={Sodium.Utilities.BinaryToBase64(sukvuk.Suk, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
+            addClientData.AppendLineWindows($"vuk={Sodium.Utilities.BinaryToBase64(sukvuk.Vuk, Sodium.Utilities.Base64Variant.UrlSafeNoPadding)}");
             if (sin != null)
                 addClientData.Append(sin);
 

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1058,14 +1058,17 @@ namespace SQRLUtilsLib
         /// <param name="count">The number of times this function was called successively.</param>
         /// <param name="priorSiteKeys">An optional list of Previous Identity Key (PIDK) key pairs to be appended to the client message.</param>
         /// <returns>Returns a <c>SQRLServerResponse</c> object representing the server's response details.</returns>
-        public static SQRLServerResponse GenerateQueryCommand(Uri sqrl, KeyPair siteKP, SQRLOptions opts = null, string encodedServerMessage=null, int count = 0, Dictionary<byte[], Tuple<byte[], KeyPair>> priorSiteKeys=null)
+        public static SQRLServerResponse GenerateQueryCommand(Uri sqrl, KeyPair siteKP, SQRLOptions opts = null, string encodedServerMessage=null, int count = 0, Dictionary<byte[], PriorSiteKeysResult> priorSiteKeys=null)
         {
             SQRLServerResponse serverResponse = null;
             if(encodedServerMessage==null)
             {
-                encodedServerMessage = Sodium.Utilities.BinaryToBase64(Encoding.UTF8.GetBytes(sqrl.OriginalString), Utilities.Base64Variant.UrlSafeNoPadding);
+                encodedServerMessage = Sodium.Utilities.BinaryToBase64(
+                    Encoding.UTF8.GetBytes(sqrl.OriginalString), 
+                    Utilities.Base64Variant.UrlSafeNoPadding);
             }
-            serverResponse = GenerateSQRLCommand(SQRLCommands.query, sqrl, siteKP, encodedServerMessage, null, opts, priorSiteKeys?.First().Value.Item2);
+            serverResponse = GenerateSQRLCommand(SQRLCommands.query, sqrl, siteKP, 
+                encodedServerMessage, null, opts, priorSiteKeys?.First().Value.KeyPair);
             if(serverResponse.CommandFailed && serverResponse.TransientError && count<=3)
             {
                 serverResponse = GenerateQueryCommand(serverResponse.NewNutURL, siteKP,opts, serverResponse.FullServerRequest,++count, priorSiteKeys);

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -1284,15 +1284,15 @@ namespace SQRLUtilsLib
         }
 
         /// <summary>
-        /// Generates an Unlock Request Signature (URS) for the given a <c>server</c> and <c>client</c>
-        /// parameter values, signed by <c>ursKey</c>.
+        /// Generates an Unlock Request Signature (URS) for the given a <paramref name="encodedServer"/> 
+        /// and <paramref name="client"/> parameter values, signed by <paramref name="ursKey"/>.
         /// </summary>
         /// <param name="encodedServer">The base64_url-encoded contents for the server parameter.</param>
         /// <param name="client">The unencoded contents for the client parameter.</param>
         /// <param name="ursKey">The Unlock Request Signing Key (URSK).</param>
-        /// <returns>Returns a <c>KeyValuePair</c>, where the key is the signature id "urs" 
-        /// and the value is the generated, base64_url-encoded signature.</returns>
-        public static KeyValuePair<string,string> GenerateURS(string encodedServer, string client, byte[] ursKey)
+        /// <returns>Returns a <c>SignatureResult</c> object containing the signature id ("urs") 
+        /// and the base64_url-encoded signature.</returns>
+        public static SignatureResult GenerateURS(string encodedServer, string client, byte[] ursKey)
         {
             return GenerateSignature("urs", encodedServer, client, ursKey);
         }
@@ -1304,9 +1304,9 @@ namespace SQRLUtilsLib
         /// <param name="encodedServer">The base64_url-encoded contents for the server parameter.</param>
         /// <param name="client">The unencoded contents for the client parameter.</param>
         /// <param name="pidkKey">The Previous Identity Key (PIDK).</param>
-        /// <returns>Returns a <c>KeyValuePair</c>, where the key is the signature id "pids" 
-        /// and the value is the generated, base64_url-encoded signature.</returns>
-        public static KeyValuePair<string, string> GeneratePIDS(string encodedServer, string client, byte[] pidkKey)
+        /// <returns>Returns a <c>SignatureResult</c> object, containing the signature id ("pids")
+        /// and the base64_url-encoded signature.</returns>
+        public static SignatureResult GeneratePIDS(string encodedServer, string client, byte[] pidkKey)
         {
             return GenerateSignature("pids", encodedServer, client, pidkKey);
         }
@@ -1318,9 +1318,9 @@ namespace SQRLUtilsLib
         /// <param name="encodedServer">The base64_url-encoded contents for the server parameter.</param>
         /// <param name="client">The unencoded contents for the client parameter.</param>
         /// <param name="idkKey">The site-specific private Identity Key (IDK).</param>
-        /// <returns>Returns a <c>KeyValuePair</c>, where the key is the signature id "ids" 
-        /// and the value is the generated, base64_url-encoded signature.</returns>
-        public static KeyValuePair<string, string> GenerateIDS(string encodedServer, string client, byte[] idkKey)
+        /// <returns>Returns a <c>SignatureResult</c> object, containing the signature id ("ids")
+        /// and the base64_url-encoded signature.</returns>
+        public static SignatureResult GenerateIDS(string encodedServer, string client, byte[] idkKey)
         {
             return GenerateSignature("ids", encodedServer, client, idkKey);
         }
@@ -1362,25 +1362,25 @@ namespace SQRLUtilsLib
 
             string encodedClient = Sodium.Utilities.BinaryToBase64(Encoding.UTF8.GetBytes(client.ToString()), Utilities.Base64Variant.UrlSafeNoPadding);
 
-            KeyValuePair<string,string> ids = GenerateIDS(encodedServer, client.ToString(), currentSiteKeyPair.PrivateKey);
+            var ids = GenerateIDS(encodedServer, client.ToString(), currentSiteKeyPair.PrivateKey);
             Dictionary<string, string> strContent = new Dictionary<string, string>()
             {
                 {"client",encodedClient },
                 {"server",encodedServer },
             };
             //Add Ids
-            strContent.Add(ids.Key,ids.Value);
+            strContent.Add(ids.SignatureType, ids.Signature);
 
             if(priorKey!=null)
             {
                 var pids = GeneratePIDS(encodedServer, client.ToString(), priorKey.PrivateKey);
-                strContent.Add(pids.Key, pids.Value);
+                strContent.Add(pids.SignatureType, pids.Signature);
             }
 
             if(ursKey!=null)
             {
                 var urs = GenerateURS(encodedServer, client.ToString(), ursKey);
-                strContent.Add(urs.Key, urs.Value);
+                strContent.Add(urs.SignatureType, urs.Signature);
             }
             using (HttpClient wc = new HttpClient())
             {

--- a/SQRLUtilsLib/SQRLServerResponse.cs
+++ b/SQRLUtilsLib/SQRLServerResponse.cs
@@ -165,7 +165,7 @@ namespace SQRLUtilsLib
         /// <summary>
         /// The Previous Identity Key (PIDK) key of the matched previous identity.
         /// </summary>
-        public KeyValuePair<byte[],Tuple<byte[], KeyPair>> PriorMatchedKey { get; set; }
+        public KeyValuePair<byte[], PriorSiteKeysResult> PriorMatchedKey { get; set; }
 
         /// <summary>
         /// The decoded plain text ask message which was transmitted by the server


### PR DESCRIPTION
Issue #54.

### Description:
This replaces anonymous `Tuple<xxx, xxx>` and `KeyValuePair<xxx, xxx>` instances used for function return values in the library with custom classes, so that the result items are properly named and the calling code is easier to read.

What still needs to be done is reflect those changes in the README, but I'll post this as a followup-commit before merging, I just wanted to get your opinion first, @josegomez.