### PR TITLE
Mac osx system notification

### DIFF
--- a/SQRLDotNetClientUI/App.xaml.cs
+++ b/SQRLDotNetClientUI/App.xaml.cs
@@ -23,18 +23,20 @@ namespace SQRLDotNetClientUI
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                // Set up the app's main window
-                desktop.MainWindow = new MainWindow
-                {
-                    DataContext = new MainWindowViewModel(),
-                };
-
+              
                 // If this is running on a Mac we need a special event handler for URL schema Invokation
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     NSApplication.Init();
                     NSApplication.SharedApplication.Delegate = new  SQRLDotNetClientUI.Platform.OSX.AppDelegate((MainWindow)desktop.MainWindow);
                 }
+
+                  // Set up the app's main window
+                desktop.MainWindow = new MainWindow
+                {
+                    DataContext = new MainWindowViewModel(),
+                };
+
                 
             }          
 

--- a/SQRLDotNetClientUI/App.xaml.cs
+++ b/SQRLDotNetClientUI/App.xaml.cs
@@ -25,6 +25,7 @@ namespace SQRLDotNetClientUI
             {
               
                 // If this is running on a Mac we need a special event handler for URL schema Invokation
+                // This also handles System Events and notifications, it gives us a native foothold on a Mac.
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     NSApplication.Init();

--- a/SQRLDotNetClientUI/Platform/Implementation.cs
+++ b/SQRLDotNetClientUI/Platform/Implementation.cs
@@ -39,7 +39,7 @@ namespace SQRLDotNetClientUI.Platform
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     return null;
                 else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                    return null;
+                    return typeof(OSX.SystemEventNotifier);
                 else return null;
             }
 

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -113,9 +113,14 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         public override void DidFinishLaunching(NSNotification notification)
         {
+            CheckIdleTime();
+        }
 
+        public static TimeSpan CheckIdleTime()
+        {
             long idlesecs = 0;
             int iter = 0;
+            TimeSpan idleTime = TimeSpan.Zero;
             if (IOServiceGetMatchingServices(0, IOServiceMatching("IOHIDSystem"), ref iter) == 0)
             {
                 int entry = IOIteratorNext(iter);
@@ -124,7 +129,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
                     IntPtr dictHandle;
                     if (IORegistryEntryCreateCFProperties(entry, out dictHandle, IntPtr.Zero, 0) == 0)
                     {
-                        NSDictionary dict =(NSDictionary) MonoMac.ObjCRuntime.Runtime.GetNSObject(dictHandle);
+                        NSDictionary dict = (NSDictionary)MonoMac.ObjCRuntime.Runtime.GetNSObject(dictHandle);
                         NSObject value;
                         dict.TryGetValue((NSString)"HIDIdleTime", out value);
                         if (value != null)
@@ -132,8 +137,8 @@ namespace SQRLDotNetClientUI.Platform.OSX
                             long nanoseconds = 0;
                             if (CFNumberGetValue(value.Handle, 4 /* kCFNumberSInt64Type = 4 */, out nanoseconds))
                             {
-                                idlesecs = nanoseconds >> 30; // Divide by 10^9 to convert from nanoseconds to seconds.
-                                Console.WriteLine(idlesecs);
+                                idlesecs = nanoseconds >> 30; // Shift To Convert from nanoseconds to seconds.
+                                idleTime = DateTime.Now - DateTime.Now.AddSeconds(-idlesecs);
                             }
                         }
                     }
@@ -141,9 +146,9 @@ namespace SQRLDotNetClientUI.Platform.OSX
                 }
                 IOObjectRelease(iter);
             }
+
+            return idleTime;
         }
-
-
     }
 
     public class Observer : NSObject

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -87,13 +87,12 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         public override void DidFinishLaunching(NSNotification notification)
         {
-            base.DidFinishLaunching(notification);
-            //NSDistributedNotificationCenter.DefaultCenter.AddObserver(new IObserver())
-            Observer observer2 = new Observer(NSDistributedNotificationCenter.DefaultCenter, new NSString("com.apple.screenIsLocked"), (obj) => {
-                Console.WriteLine("123");
-            });
             
-            NSDistributedNotificationCenter.DefaultCenter.AddObserver(observer2, new NSString("com.apple.screenIsLocked"), NSKeyValueObservingOptions.Initial,observer2.Handle);
+            
+            ((NSDistributedNotificationCenter)NSDistributedNotificationCenter.DefaultCenter).AddObserver(new NSString("com.apple.screenIsLocked"), (obj) =>
+            {
+                Console.WriteLine("Hello");
+            });
         }
 
 

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -48,9 +48,6 @@ namespace SQRLDotNetClientUI.Platform.OSX
         [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
         static extern bool CFNumberGetValue(IntPtr number, int theType, out long value);
 
-        
-        //public NSStatusItem statusBarItem;
-
         // Instance Window of our App
         Window mainWindow = null;
 
@@ -71,6 +68,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         /// </summary>
         private void Init()
         {
+            //Register this Apple Delegate globablly with Avalonia for Later Use
             AvaloniaLocator.CurrentMutable.Bind<AppDelegate>().ToConstant(this);
             NSAppleEventManager.SharedAppleEventManager.SetEventHandler(this, new MonoMac.ObjCRuntime.Selector("handleGetURLEvent:withReplyEvent:"), AEEventClass.Internet, AEEventID.GetUrl);
         }
@@ -114,10 +112,14 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         public override void DidFinishLaunching(NSNotification notification)
         {
-            //CheckIdleTime();
             FinishedLaunching = true;
         }
 
+
+        /// <summary>
+        /// Checks the System's Environment Variable HIDIdleTime which is maintained by apple to register last Keyboard or Mouse Input
+        /// </summary>
+        /// <returns></returns>
         public static TimeSpan CheckIdleTime()
         {
             long idlesecs = 0;

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -23,7 +23,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
     [Register("AppDelegate")]
     public class AppDelegate : NSApplicationDelegate
     {
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        /*[DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
         static extern int IOServiceGetMatchingServices(uint masterPort, IntPtr matching, ref int existing);
 
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
@@ -47,7 +47,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
         static extern bool CFNumberGetValue(IntPtr number, int theType, out long value);
 
-
+        */
         //public NSStatusItem statusBarItem;
 
         // Instance Window of our App
@@ -113,10 +113,10 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         public override void DidFinishLaunching(NSNotification notification)
         {
-            CheckIdleTime();
+            //CheckIdleTime();
         }
 
-        public static TimeSpan CheckIdleTime()
+        /*public static TimeSpan CheckIdleTime()
         {
             long idlesecs = 0;
             int iter = 0;
@@ -135,7 +135,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
                         if (value != null)
                         {
                             long nanoseconds = 0;
-                            if (CFNumberGetValue(value.Handle, 4 /* kCFNumberSInt64Type = 4 */, out nanoseconds))
+                            if (CFNumberGetValue(value.Handle, 4 , out nanoseconds))
                             {
                                 idlesecs = nanoseconds >> 30; // Shift To Convert from nanoseconds to seconds.
                                 idleTime = DateTime.Now - DateTime.Now.AddSeconds(-idlesecs);
@@ -148,108 +148,10 @@ namespace SQRLDotNetClientUI.Platform.OSX
             }
 
             return idleTime;
-        }
+        }*/
     }
 
-    public class Observer : NSObject
-    {
-        // Fields
-        private Action<NSObservedChange> cback;
-        private NSString key;
-        private WeakReference obj;
-
-        // Methods
-        public Observer(NSObject obj, NSString key, Action<NSObservedChange> observer)
-        {
-            if (observer == null)
-            {
-                throw new ArgumentNullException("observer");
-            }
-            this.obj = new WeakReference(obj);
-            this.key = key;
-            this.cback = observer;
-            base.IsDirectBinding = false;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (this.obj != null)
-                {
-                    NSObject target = (NSObject)this.obj.Target;
-                    if (target != null)
-                    {
-                        target.RemoveObserver(this, this.key);
-                    }
-                }
-                this.obj = null;
-                this.cback = null;
-            }
-            else
-            {
-                Console.WriteLine("Warning: observer object was not disposed manually with Dispose()");
-            }
-            base.Dispose(disposing);
-        }
-
-        [Preserve(Conditional = true)]
-        public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
-        {
-            if ((keyPath == this.key) && (context == base.Handle))
-            {
-                this.cback(new NSObservedChange(change));
-            }
-            else
-            {
-                base.ObserveValue(keyPath, ofObject, change, context);
-            }
-        }
-    }
-
-
-    public class NSObservedChange
-    {
-        // Fields
-        private NSDictionary dict;
-
-        // Methods
-        public NSObservedChange(NSDictionary source)
-        {
-            this.dict = source;
-        }
-
-        // Properties
-        public NSKeyValueChange Change
-        {
-            get
-            {
-                NSNumber number = (NSNumber)this.dict[NSObject.ChangeKindKey];
-                return (NSKeyValueChange)number.Int32Value;
-            }
-        }
-
-        public NSIndexSet Indexes =>
-            ((NSIndexSet)this.dict[NSObject.ChangeIndexesKey]);
-
-        public bool IsPrior
-        {
-            get
-            {
-                NSNumber number = this.dict[NSObject.ChangeNotificationIsPriorKey] as NSNumber;
-                if (number == null)
-                    return false;
-                return number.BoolValue;
-            }
-        }
-
-        public NSObject NewValue =>
-            this.dict[NSObject.ChangeNewKey];
-
-        public NSObject OldValue =>
-            this.dict[NSObject.ChangeOldKey];
-    }
-
+    
 
 
 }

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -85,7 +85,14 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         }
 
+        public override void DidFinishLaunching(NSNotification notification)
+        {
+            base.DidFinishLaunching(notification);
+            NSDistributedNotificationCenter.DefaultCenter.AddObserver("com.apple.screenIsLocked",NSKeyValueObservingOptions.Initial, (obj) => {
+                Console.WriteLine("123");
+            });
+        }
 
-       
+
     }
 }

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate .cs
@@ -23,7 +23,8 @@ namespace SQRLDotNetClientUI.Platform.OSX
     [Register("AppDelegate")]
     public class AppDelegate : NSApplicationDelegate
     {
-        /*[DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        public bool FinishedLaunching = false;
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
         static extern int IOServiceGetMatchingServices(uint masterPort, IntPtr matching, ref int existing);
 
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
@@ -47,7 +48,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
         static extern bool CFNumberGetValue(IntPtr number, int theType, out long value);
 
-        */
+        
         //public NSStatusItem statusBarItem;
 
         // Instance Window of our App
@@ -70,7 +71,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         /// </summary>
         private void Init()
         {
-            
+            AvaloniaLocator.CurrentMutable.Bind<AppDelegate>().ToConstant(this);
             NSAppleEventManager.SharedAppleEventManager.SetEventHandler(this, new MonoMac.ObjCRuntime.Selector("handleGetURLEvent:withReplyEvent:"), AEEventClass.Internet, AEEventID.GetUrl);
         }
         /// <summary>
@@ -114,9 +115,10 @@ namespace SQRLDotNetClientUI.Platform.OSX
         public override void DidFinishLaunching(NSNotification notification)
         {
             //CheckIdleTime();
+            FinishedLaunching = true;
         }
 
-        /*public static TimeSpan CheckIdleTime()
+        public static TimeSpan CheckIdleTime()
         {
             long idlesecs = 0;
             int iter = 0;
@@ -148,7 +150,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
             }
 
             return idleTime;
-        }*/
+        }
     }
 
     

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
@@ -23,14 +23,16 @@ namespace SQRLDotNetClientUI.Platform.OSX
     [Register("AppDelegate")]
     public class AppDelegate : NSApplicationDelegate
     {
-        public bool FinishedLaunching = false;
+        public bool IsFinishedLaunching = false;
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
         static extern int IOServiceGetMatchingServices(uint masterPort, IntPtr matching, ref int existing);
 
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
         static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
 
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+#pragma warning restore CA2101 // Specify marshaling for P/Invoke string arguments
         static extern IntPtr IOServiceMatching(string s);
 
         [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
@@ -112,7 +114,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         public override void DidFinishLaunching(NSNotification notification)
         {
-            FinishedLaunching = true;
+            IsFinishedLaunching = true;
         }
 
 

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -70,7 +70,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
             });
 
 
-            _pollTask = new Task(() =>
+            /*_pollTask = new Task(() =>
             {
                 Log.Information("SystemEventNotifier polling task started");
 
@@ -102,7 +102,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
             }, _ct);
 
             _pollTask.Start();
-        }
+        }*/
 
     }
 }

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -1,0 +1,62 @@
+﻿using MonoMac.Foundation;
+using Serilog;
+using SQRLDotNetClientUI.Models;
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+using Foundation;
+using AppKit;
+namespace SQRLDotNetClientUI.Platform.OSX
+{
+    public class SystemEventNotifier : ISystemEventNotifier
+    {
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IOServiceGetMatchingServices(uint masterPort, IntPtr matching, ref int existing);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IOServiceMatching(string s);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern IntPtr IORegistryEntryCreateCFProperty(uint entry, IntPtr key, IntPtr allocator, uint options);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IOObjectRelease(int o);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IOIteratorNext(int o);
+
+        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
+        static extern int IORegistryEntryCreateCFProperties(int entry, out IntPtr eproperties, IntPtr allocator, uint options);
+
+        [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
+        static extern bool CFNumberGetValue(IntPtr number, int theType, out long value);
+
+        public event EventHandler<SystemEventArgs> Idle;
+        public event EventHandler<SystemEventArgs> Screensaver;
+        public event EventHandler<SystemEventArgs> Standby;
+        public event EventHandler<SystemEventArgs> SessionLogoff;
+        public event EventHandler<SystemEventArgs> SessionLock;
+        public event EventHandler<SystemEventArgs> ShutdownOrRestart;
+
+        public SystemEventNotifier()
+        {
+            ((NSDistributedNotificationCenter)NSDistributedNotificationCenter.DefaultCenter).AddObserver(new NSString("com.apple.screenIsLocked"), (obj) =>
+            {
+                Log.Information("Detected Screen Saver");
+                Screensaver?.Invoke(this, new SystemEventArgs("Screensaver"));
+            });
+
+            ((NSDistributedNotificationCenter)NSDistributedNotificationCenter.DefaultCenter).AddObserver(new NSString("com.apple.screensaver.didstart"), (obj) =>
+            {
+                Log.Information("Detected session lock");
+                Screensaver?.Invoke(this, new SystemEventArgs("Session Lock"));
+                
+            });
+        }
+    }
+}

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -13,7 +13,7 @@ using System.Threading.Tasks;
 namespace SQRLDotNetClientUI.Platform.OSX
 {
     /// <summary>
-    /// Provides access to Windows system events that are relevant to the 
+    /// Provides access to MacOSX system events that are relevant to the 
     /// clearing of QuickPass-related data from RAM, like entering
     /// an idle state, logging off or entering a sleep or hilbernation
     /// state etc.
@@ -35,7 +35,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         private CancellationTokenSource _cts = null;
         private CancellationToken _ct;
         private Task _pollTask = null;
-        private bool _screensaverDetected = false;
+        
         private bool _idleDetected = false;
         private int _maxIdleSeconds = 60 * 15; // Set a sensible default, will be overwritten anyway
 
@@ -55,6 +55,8 @@ namespace SQRLDotNetClientUI.Platform.OSX
         /// <c>Idle</c> event is being raised.</param>
         public SystemEventNotifier(int maxIdleSeconds = 60 * 15)
         {
+            _cts = new CancellationTokenSource();
+            _ct = _cts.Token;
 
             this._maxIdleSeconds = maxIdleSeconds;
             
@@ -62,7 +64,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
             ((NSDistributedNotificationCenter)NSDistributedNotificationCenter.DefaultCenter).AddObserver(new NSString("com.apple.screenIsLocked"), (obj) =>
             {
                 Log.Information("Detected session lock");
-                Screensaver?.Invoke(this, new SystemEventArgs("Session Lock"));
+                SessionLock?.Invoke(this, new SystemEventArgs("Session Lock"));
             });
 
             //Subscribe to an apple notification fired when the screen saver starts
@@ -133,7 +135,13 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
             _pollTask.Start();
         }
-
+        ~SystemEventNotifier()
+        {
+            // Cancel the polling task
+            _cts.Cancel();
+        }
     }
+
+   
 
 }

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -50,12 +50,14 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
             });
 
-            NSWorkspace.Notifications.ObserveWillSleep((s, e) =>{
+            NSWorkspace.Notifications.ObserveWillSleep((s, e) =>
+            {
                 Log.Information("Detected Standy");
                 Standby?.Invoke(this, new SystemEventArgs("Stand By"));
             });
 
-            NSWorkspace.Notifications.ObserveWillPowerOff((s, e) => {
+            NSWorkspace.Notifications.ObserveWillPowerOff((s, e) =>
+            {
                 Log.Information("Detected PowerOff / Reboot");
                 ShutdownOrRestart?.Invoke(this, new SystemEventArgs("System ShutDown / Reboot"));
             });
@@ -75,7 +77,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
                 while (!_ct.IsCancellationRequested)
                 {
                     // Check system idle time
-                    TimeSpan idletime= AppDelegate.CheckIdleTime();
+                    TimeSpan idletime = AppDelegate.CheckIdleTime();
                     Log.Debug("Idle time: {IdleTime}", idletime.ToString());
                     if (idletime.TotalSeconds > _maxIdleSeconds)
                     {
@@ -101,6 +103,6 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
             _pollTask.Start();
         }
-    }
+
     }
 }

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -1,40 +1,31 @@
-﻿using MonoMac.Foundation;
+﻿using MonoMac.AppKit;
+using MonoMac.Foundation;
 using Serilog;
 using SQRLDotNetClientUI.Models;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Text;
-using Foundation;
-using AppKit;
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SQRLDotNetClientUI.Platform.OSX
 {
     public class SystemEventNotifier : ISystemEventNotifier
     {
 
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern int IOServiceGetMatchingServices(uint masterPort, IntPtr matching, ref int existing);
+        /// <summary>
+        /// Specifies the checking interval for the polling thread.
+        /// </summary>
+        private readonly int POLL_INTERVAL = 5000;
 
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern uint IOServiceGetMatchingService(uint masterPort, IntPtr matching);
 
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern IntPtr IOServiceMatching(string s);
-
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern IntPtr IORegistryEntryCreateCFProperty(uint entry, IntPtr key, IntPtr allocator, uint options);
-
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern int IOObjectRelease(int o);
-
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern int IOIteratorNext(int o);
-
-        [DllImport("/System/Library/Frameworks/IOKit.framework/IOKit")]
-        static extern int IORegistryEntryCreateCFProperties(int entry, out IntPtr eproperties, IntPtr allocator, uint options);
-
-        [DllImport("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation")]
-        static extern bool CFNumberGetValue(IntPtr number, int theType, out long value);
+        private CancellationTokenSource _cts = null;
+        private CancellationToken _ct;
+        private Task _pollTask = null;
+        private bool _screensaverDetected = false;
+        private bool _idleDetected = false;
+        private int _maxIdleSeconds = 60 * 15; // Set a sensible default, will be overwritten anyway
 
         public event EventHandler<SystemEventArgs> Idle;
         public event EventHandler<SystemEventArgs> Screensaver;
@@ -43,8 +34,9 @@ namespace SQRLDotNetClientUI.Platform.OSX
         public event EventHandler<SystemEventArgs> SessionLock;
         public event EventHandler<SystemEventArgs> ShutdownOrRestart;
 
-        public SystemEventNotifier()
+        public SystemEventNotifier(int maxIdleSeconds = 60 * 15)
         {
+            this._maxIdleSeconds = maxIdleSeconds;
             ((NSDistributedNotificationCenter)NSDistributedNotificationCenter.DefaultCenter).AddObserver(new NSString("com.apple.screenIsLocked"), (obj) =>
             {
                 Log.Information("Detected Screen Saver");
@@ -55,8 +47,60 @@ namespace SQRLDotNetClientUI.Platform.OSX
             {
                 Log.Information("Detected session lock");
                 Screensaver?.Invoke(this, new SystemEventArgs("Session Lock"));
-                
+
             });
+
+            NSWorkspace.Notifications.ObserveWillSleep((s, e) =>{
+                Log.Information("Detected Standy");
+                Standby?.Invoke(this, new SystemEventArgs("Stand By"));
+            });
+
+            NSWorkspace.Notifications.ObserveWillPowerOff((s, e) => {
+                Log.Information("Detected PowerOff / Reboot");
+                ShutdownOrRestart?.Invoke(this, new SystemEventArgs("System ShutDown / Reboot"));
+            });
+
+            NSWorkspace.Notifications.ObserveSessionDidResignActive((s, e) =>
+            {
+                Log.Information("Detected PowerOff / Reboot");
+                SessionLogoff?.Invoke(this, new SystemEventArgs("Session Log Off"));
+
+            });
+
+
+            _pollTask = new Task(() =>
+            {
+                Log.Information("SystemEventNotifier polling task started");
+
+                while (!_ct.IsCancellationRequested)
+                {
+                    // Check system idle time
+                    TimeSpan idletime= AppDelegate.CheckIdleTime();
+                    Log.Debug("Idle time: {IdleTime}", idletime.ToString());
+                    if (idletime.TotalSeconds > _maxIdleSeconds)
+                    {
+                        if (!_idleDetected)
+                        {
+                            Idle?.Invoke(this, new SystemEventArgs("Idle Timeout"));
+                            Log.Information("Detected idle timeout");
+                            _idleDetected = true;
+                        }
+                    }
+                    else
+                    {
+                        if (_idleDetected)
+                            _idleDetected = false;
+                    }
+
+                    Thread.Sleep(POLL_INTERVAL);
+                }
+
+                Log.Information("SystemEventNotifier polling task ending");
+
+            }, _ct);
+
+            _pollTask.Start();
         }
+    }
     }
 }

--- a/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/SystemEventNotifier.cs
@@ -35,7 +35,7 @@ namespace SQRLDotNetClientUI.Platform.OSX
         public event EventHandler<SystemEventArgs> SessionLock;
         public event EventHandler<SystemEventArgs> ShutdownOrRestart;
 
-        public  SystemEventNotifier(int maxIdleSeconds = 60 * 15)
+        public SystemEventNotifier(int maxIdleSeconds = 60 * 15)
         {
             Task.Run(() =>
             {
@@ -74,13 +74,13 @@ namespace SQRLDotNetClientUI.Platform.OSX
                     SessionLogoff?.Invoke(this, new SystemEventArgs("Session Log Off"));
 
                 });
-            });
+            }).Start();
 
 
             _pollTask = new Task(() =>
             {
                 Log.Information("SystemEventNotifier polling task started");
-
+                Thread.Sleep(POLL_INTERVAL); //Sleep at first to give Mac Delegate time
                 while (!_ct.IsCancellationRequested)
                 {
                     // Check system idle time
@@ -111,6 +111,6 @@ namespace SQRLDotNetClientUI.Platform.OSX
             _pollTask.Start();
         }
 
-        }
     }
+
 }

--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -141,7 +141,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="MonoMac.NetStandard" Version="0.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="protobuf-net" Version="2.4.4" />
     <PackageReference Include="QRCoder" Version="1.3.6" />
@@ -227,6 +226,11 @@
     <EmbeddedResource Include="Views\MessageBox.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="XamMac">
+      <HintPath>D:\Apps\XamMac.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Update="sqrl.db">

--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -127,9 +127,9 @@
     <PackageReference Include="Avalonia" Version="0.9.4" />
     <PackageReference Include="Avalonia.Desktop" Version="0.9.4" />
     <PackageReference Include="Avalonia.ReactiveUI" Version="0.9.4" />
-    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.9.3" />
-    <PackageReference Include="Avalonia.Xaml.Interactions.Custom" Version="0.9.3" />
-    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="0.9.3" />
+    <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.9.4" />
+    <PackageReference Include="Avalonia.Xaml.Interactions.Custom" Version="0.9.4" />
+    <PackageReference Include="Avalonia.Xaml.Interactivity" Version="0.9.4" />
     <PackageReference Include="Eto.Forms" Version="2.5.0" />
     <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.1.2">
@@ -141,6 +141,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MonoMac.NetStandard" Version="0.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="protobuf-net" Version="2.4.4" />
     <PackageReference Include="QRCoder" Version="1.3.6" />
@@ -226,11 +227,6 @@
     <EmbeddedResource Include="Views\MessageBox.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="XamMac">
-      <HintPath>D:\Apps\XamMac.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <None Update="sqrl.db">


### PR DESCRIPTION
This Implements the System Notifications for MacOSX.

It does this by implementing an AppleAppDelegate and subscribing to several notification events which apple sends out when 
Screen Locks
Screen Saver Starts
System Logs Off
System Reboots

Also implemented a polling Task which checks the HIDIdleTime (A system Maintained environment value which tracks how long since last mouse / keyboard input) and raises an event if it goes above the pre-set threshold.