### PR TITLE
Backport ProgressDialog

### DIFF
--- a/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
@@ -21,22 +21,6 @@ namespace SQRLDotNetClientUI.ViewModels
             set => this.RaiseAndSetIfChanged(ref _canSave, value); 
         }
 
-        private double _ProgressPercentage = 0;
-        public double ProgressPercentage 
-        { 
-            get => _ProgressPercentage; 
-            set => this.RaiseAndSetIfChanged(ref _ProgressPercentage, value); 
-        }
-
-        public double ProgressMax { get; set; } = 100;
-
-        private string _progressText = string.Empty;
-        public string ProgressText 
-        { 
-            get => _progressText; 
-            set => this.RaiseAndSetIfChanged(ref _progressText, value); 
-        }
-
         public IdentitySettingsViewModel()
         {
             this.Title = _loc.GetLocalizationValue("IdentitySettingsDialogTitle");

--- a/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
@@ -59,29 +59,28 @@ namespace SQRLDotNetClientUI.ViewModels
                 return;
             }
 
-            var progress = new Progress<KeyValuePair<int, string>>(p =>
-            {
-                this.ProgressPercentage = (double)p.Key;
-                this.ProgressText = p.Value + p.Key;
-            });
-
+            var progress = new Progress<KeyValuePair<int, string>>();
+            var progressDialog = new ProgressDialog(progress);
+            _ = progressDialog.ShowDialog(_mainWindow);
             var block1Keys = await SQRL.DecryptBlock1(Identity, password, progress);
 
             if (!block1Keys.DecryptionSucceeded)
             {
+                progressDialog.Close();
 
                 await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                           _loc.GetLocalizationValue("BadPasswordError"), 
-                                           MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                           .ShowDialog<MessagBoxDialogResult>(_mainWindow);
-                ProgressText = "";
-                ProgressPercentage = 0;
+                    _loc.GetLocalizationValue("BadPasswordError"), 
+                    MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+
                 CanSave = true;
                 return;
             }
 
             SQRLIdentity id = await SQRL.GenerateIdentityBlock1(block1Keys.Imk, block1Keys.Ilk, 
                 password, IdentityCopy, progress, IdentityCopy.Block1.PwdVerifySeconds);
+
+            progressDialog.Close();
 
             // Swap out the old type 1 block with the updated one
             // TODO: We should probably make sure that this is an atomic operation

--- a/SQRLDotNetClientUI/Views/IdentitySettingsView.xaml
+++ b/SQRLDotNetClientUI/Views/IdentitySettingsView.xaml
@@ -4,13 +4,8 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:Class="SQRLDotNetClientUI.Views.IdentitySettingsView">
-
-  <!-- Data binding source -->
-  <Design.DataContext>
-    <vm:IdentitySettingsViewModel/>
-  </Design.DataContext>
 
   <!-- Layout start -->
   <DockPanel Margin="15" LastChildFill="False">
@@ -66,13 +61,7 @@
       <CheckBox Content="{loc:Localization WarnOfNonCPSAuth}" IsChecked="{Binding IdentityCopy.Block1.OptionFlags.EnableNoCPSWarning}" IsEnabled="{Binding CanSave}" 
                 Margin="15,3,0,0" Grid.Row="12" Grid.Column="0" Grid.ColumnSpan="2" />
     </Grid>
-
-    <Grid DockPanel.Dock="Bottom" Height="25">
-      <ProgressBar Margin="10,0,10,0" IsIndeterminate="False" Value="{Binding ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true" Height="20"/>
-      <TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Text="{Binding ProgressText}"/>
-    </Grid>
-
-    
+   
     <DockPanel Margin="15" DockPanel.Dock="Bottom" LastChildFill="False">
       <Button Content="{loc:Localization BtnCancel}" Command="{Binding Close}" IsEnabled="{Binding CanSave}" Width="100" Height="30" DockPanel.Dock="Left" />
       <Button Content="{loc:Localization BtnSave}" Command="{Binding Save}" IsEnabled="{Binding CanSave}" Width="100" Height="30" DockPanel.Dock="Right" />

--- a/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
@@ -2,14 +2,13 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
+             xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:Class="SQRLDotNetClientUI.Views.ImportIdentitySetupView">
   
-  <Design.DataContext>
-    <vm:ImportIdentitySetupViewModel/>
-  </Design.DataContext>
   
   <StackPanel>
     <Grid ShowGridLines="False">
@@ -21,11 +20,12 @@
         <RowDefinition />
         <RowDefinition />
         <RowDefinition />
-        <RowDefinition  />
-        <RowDefinition  />
-        <RowDefinition  />
-        <RowDefinition  />
-        <RowDefinition  />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
+        <RowDefinition />
       </Grid.RowDefinitions>
       
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
@@ -35,50 +35,19 @@
 
       <TextBlock Margin="10" Text="{loc:Localization IdentityNameLabel}" Grid.Row="1" Grid.Column="0" />
       <loc:CopyPasteTextBox Margin="10" Text="{Binding IdentityName}" Width="250" HorizontalAlignment="Left" Grid.Row="1" Grid.Column="1"/>
-      
-      <TextBlock Margin="10" Text="{loc:Localization NewPasswordLabel}" Grid.Row="2" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" PasswordChar="*" Grid.Row="2" Grid.Column="1"/>
 
-      <TextBlock Margin="10" Text="{loc:Localization RetypePasswordLabel}" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
-      
-      <TextBlock Margin="10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="4" Grid.Column="0"/>
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding RescueCode}" Width="250" HorizontalAlignment="Left" Grid.Row="4" Grid.Column="1"  />
-      
-      <Panel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="10">
-        <Grid ShowGridLines="False" >
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*" />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <ProgressBar IsIndeterminate="False" Value="{Binding Block2DecryptProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true"  Height="20" MinWidth="10"  Grid.Row="0" Grid.Column="0" Foreground="LightGreen"/>
-          <ProgressBar IsIndeterminate="False" Value="{Binding Block1ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10" Grid.Row="0" Grid.Column="1" Foreground="LightGreen" />
-          <ProgressBar IsIndeterminate="False" Value="{Binding Block2ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true"  Height="20" MinWidth="10"  Grid.Row="0" Grid.Column="2" Foreground="LightGreen"/>
-        </Grid>
-      </Panel>
-      <Panel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,-10,10,10">
+      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
+      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding RescueCode}" Width="250" HorizontalAlignment="Left" Grid.Row="2" Grid.Column="1"  />
 
-        <Grid ShowGridLines="False">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
-            <ColumnDefinition />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          <TextBlock Text="{loc:Localization DecryptingBlock2Label}" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Center" FontWeight="DemiBold"/>
-          <TextBlock Text="{loc:Localization EncryptingBlock1Label}" Grid.Row="0" Grid.Column="1" HorizontalAlignment="Center" FontWeight="DemiBold" />
-          <TextBlock Text="{loc:Localization EncryptingBlock2Label}" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Center" FontWeight="DemiBold" />
-        </Grid>
-      </Panel>
+      <TextBlock Margin="10" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0" />
+      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
 
-      <Button Content="{loc:Localization BtnNext}" Margin="10" Command="{Binding VerifyAndImportIdentity}" Grid.Row="7" Grid.Column="0" Width="90" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnCancel}" Margin="10,10,20,10" Command="{Binding Cancel}" Grid.Row="7" Grid.Column="1" Width="90" HorizontalAlignment="Right" />
+      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0" />
+      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
+                            PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
+
+      <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="8" Grid.Column="0" Width="90" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnNext}" IsDefault="True" Margin="10,10,20,10" Command="{Binding VerifyAndImportIdentity}" Grid.Row="8" Grid.Column="1" Width="90" HorizontalAlignment="Right" />
 
     </Grid>
   </StackPanel>

--- a/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
@@ -31,10 +31,14 @@
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
       
-      <TextBlock Margin="10" Text="{loc:Localization ImportSetupMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
+      <TextBlock Text="{loc:Localization ImportSetupMessage}" Margin="10" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
 
-      <TextBlock Margin="10" Text="{loc:Localization IdentityNameLabel}" Grid.Row="1" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding IdentityName}" Width="250" HorizontalAlignment="Left" Grid.Row="1" Grid.Column="1"/>
+      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10" Grid.Row="1" Grid.Column="0" />
+      <loc:CopyPasteTextBox Text="{Binding IdentityName}" Name="txtIdentityName" Margin="10" Width="250" HorizontalAlignment="Left" Grid.Row="1" Grid.Column="1">
+        <i:Interaction.Behaviors>
+          <behaviors:FocusOnAttached />
+        </i:Interaction.Behaviors>
+      </loc:CopyPasteTextBox>
 
       <TextBlock Margin="10,0,10,10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
       <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding RescueCode}" Width="250" HorizontalAlignment="Left" Grid.Row="2" Grid.Column="1"  />

--- a/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using SQRLDotNetClientUI.AvaloniaExtensions;
 
 namespace SQRLDotNetClientUI.Views
 {
@@ -14,6 +15,12 @@ namespace SQRLDotNetClientUI.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+
+            // This is only here because for some reason the XAML behaviour "FocusOnAttached"
+            // isn't working for this window. No clue why, probably a dumb mistake on my part.
+            // If anyone gets this working in XAML, this ugly hack can be removed!
+            this.FindControl<CopyPasteTextBox>("txtIdentityName").AttachedToVisualTree +=
+                (sender, e) => (sender as CopyPasteTextBox).Focus();
         }
     }
 }

--- a/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
@@ -6,11 +6,7 @@
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
              x:Class="SQRLDotNetClientUI.Views.ImportIdentityView">
-  
-  <Design.DataContext>
-    <vm:ImportIdentityViewModel/>
-  </Design.DataContext>
-  
+   
   <Grid ShowGridLines="False" Width="400">
     <Grid.ColumnDefinitions>
       <ColumnDefinition Width="100" />
@@ -37,8 +33,8 @@
     <TextBlock Margin="10,10,10,5" FontWeight="Bold" Text="{Binding IdentityFile}"  FontSize="12" TextWrapping="Wrap" 
                Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" VerticalAlignment="Center"/>
 
-    <Button Content="{loc:Localization BtnNext}" Margin="10" Command="{Binding ImportVerify}" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="1" Width="70" HorizontalAlignment="Left" />
-    <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="5" Grid.Column="1" Grid.ColumnSpan="1" Width="70" HorizontalAlignment="Right" />
+    <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="5" Grid.Column="0" Width="70" HorizontalAlignment="Left" />
+    <Button Content="{loc:Localization BtnNext}" IsDefault="True" Margin="10" Command="{Binding ImportVerify}" Grid.Row="5" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
     
   </Grid>
 </UserControl>

--- a/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml
+++ b/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml
@@ -2,14 +2,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
              x:Class="SQRLDotNetClientUI.Views.NewIdentityVerifyView">
-  
-  <Design.DataContext>
-    <vm:NewIdentityVerifyViewModel/>
-  </Design.DataContext>
   
   <StackPanel>
     <Grid ShowGridLines="False">
@@ -30,48 +28,18 @@
       
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
+      
       <TextBlock Margin="10" Text="{loc:Localization NewIdentityVerifyMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
 
       <TextBlock Margin="10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding RescueCode}" Grid.Row="2" Grid.Column="1"  />
-      
-      <TextBlock Margin="10" Text="{loc:Localization PasswordLabel}" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding Password}" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
-      
-      <Panel Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="10">
-        <Grid ShowGridLines="False" >
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="*"/>
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-           </Grid.RowDefinitions>
-          <ProgressBar IsIndeterminate="False" Value="{Binding Block2ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10" Grid.Row="0" Grid.Column="1"/>
-          <ProgressBar IsIndeterminate="False" Value="{Binding Block1ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true"  Height="20" MinWidth="10"  Grid.Row="0" Grid.Column="0"/>
-        </Grid>
-      </Panel>
-      <Panel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,2,10,10">
-        
-        <Grid ShowGridLines="False">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
-            <ColumnDefinition />
-          </Grid.ColumnDefinitions>
-          <Grid.RowDefinitions>
-            <RowDefinition />
-          </Grid.RowDefinitions>
-          
-          <TextBlock Text="{loc:Localization DecryptingBlock1Label}" Grid.Row="0" Grid.Column="0" HorizontalAlignment="Right" />
-          <Image Grid.Row="0" Grid.Column="1" Source="resm:SQRLDotNetClientUI.Assets.VL.png" Height="25" Stretch="Uniform"/>
-          <TextBlock Text="{loc:Localization DecryptingBlock2Label}" Grid.Row="0" Grid.Column="2" HorizontalAlignment="Left" TextAlignment="Right" />
-          
-        </Grid>
-      </Panel>
-      
-      <Button Content="{loc:Localization BtnNext}" Margin="10" Command="{Binding VerifyRescueCode}" Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="1" Width="70" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnBack}" Margin="10" Command="{Binding GenerateNewIdentity}" Grid.Row="7" Grid.Column="1" Grid.ColumnSpan="1" Width="70" HorizontalAlignment="Right" />
+      <loc:CopyPasteTextBox Margin="10" Text="{Binding RescueCode}" Grid.Row="2" Grid.Column="1">
+        <i:Interaction.Behaviors>
+          <behaviors:FocusOnAttached />
+        </i:Interaction.Behaviors>
+      </loc:CopyPasteTextBox>
+
+      <Button Content="{loc:Localization BtnBack}" Margin="10" Command="{Binding GenerateNewIdentity}" Grid.Row="7" Grid.Column="0" Width="70" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnNext}" IsDefault="True" Margin="10" Command="{Binding VerifyRescueCode}" Grid.Row="7" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
       
     </Grid>
   </StackPanel>

--- a/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml
+++ b/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml
@@ -29,10 +29,10 @@
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
       
-      <TextBlock Margin="10" Text="{loc:Localization NewIdentityVerifyMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
+      <TextBlock Text="{loc:Localization NewIdentityVerifyMessage}" Margin="10"  FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
 
-      <TextBlock Margin="10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding RescueCode}" Grid.Row="2" Grid.Column="1">
+      <TextBlock Text="{loc:Localization RescueCodeLabel}" Margin="10" Grid.Row="2" Grid.Column="0"/>
+      <loc:CopyPasteTextBox Text="{Binding RescueCode}" Name="txtRescueCode" Grid.Row="2" Margin="10" Grid.Column="1">
         <i:Interaction.Behaviors>
           <behaviors:FocusOnAttached />
         </i:Interaction.Behaviors>

--- a/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewIdentityVerifyView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using SQRLDotNetClientUI.AvaloniaExtensions;
 
 namespace SQRLDotNetClientUI.Views
 {
@@ -14,6 +15,12 @@ namespace SQRLDotNetClientUI.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+
+            // This is only here because for some reason the XAML behaviour "FocusOnAttached"
+            // isn't working for this window. No clue why, probably a dumb mistake on my part.
+            // If anyone gets this working in XAML, this ugly hack can be removed!
+            this.FindControl<CopyPasteTextBox>("txtRescueCode").AttachedToVisualTree +=
+                (sender, e) => (sender as CopyPasteTextBox).Focus();
         }
     }
 }

--- a/SQRLDotNetClientUI/Views/NewIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/NewIdentityView.xaml
@@ -2,6 +2,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
@@ -28,21 +30,23 @@
       <TextBlock Margin="10" Text="{loc:Localization NewIdentityMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
       
       <TextBlock Margin="10" Text="{loc:Localization IdentityNameLabel}" Grid.Row="1" Grid.Column="0" TextAlignment="Left"/>
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding IdentityName}" Grid.Row="1" Grid.Column="1"/>
+      <loc:CopyPasteTextBox Margin="10" Text="{Binding IdentityName}" Grid.Row="1" Grid.Column="1">
+        <i:Interaction.Behaviors>
+          <behaviors:FocusOnAttached />
+        </i:Interaction.Behaviors>
+      </loc:CopyPasteTextBox>
        
       <TextBlock Margin="10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
       <loc:CopyPasteTextBox Margin="10"  Text="{Binding RescueCode}" Grid.Row="2" Grid.Column="1" IsReadOnly="True"  />
        
       <TextBlock Margin="10" Text="{loc:Localization PasswordLabel}" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding Password}" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
+      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding Password}" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
       
       <TextBlock Margin="10" Text="{loc:Localization RetypePasswordLabel}" Grid.Row="4" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding PasswordConfirm}" PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
+      <loc:CopyPasteTextBox Margin="10,0,10,20" Text="{Binding PasswordConfirm}" PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
       
-      <ProgressBar Margin="10" IsIndeterminate="False" Value="{Binding ProgressPercentage}" Maximum="{Binding ProgressMax}" Minimum="0" IsEnabled="true" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Height="20"/>
-      
-      <Button Content="{loc:Localization BtnNext}" Margin="10" Command="{Binding GenerateNewIdentity}" Grid.Row="6" Grid.Column="0" Width="70" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="6" Grid.Column="1"  Width="70" HorizontalAlignment="Right" />
+      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Cancel}" Margin="10" Grid.Row="6" Grid.Column="0"  Width="70" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnNext}" Command="{Binding GenerateNewIdentity}" IsDefault="True" Margin="10" Grid.Row="6" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
       
     </Grid>
   </StackPanel>

--- a/SQRLDotNetClientUI/Views/NewIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/NewIdentityView.xaml
@@ -29,8 +29,8 @@
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
       <TextBlock Margin="10" Text="{loc:Localization NewIdentityMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
       
-      <TextBlock Margin="10" Text="{loc:Localization IdentityNameLabel}" Grid.Row="1" Grid.Column="0" TextAlignment="Left"/>
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding IdentityName}" Grid.Row="1" Grid.Column="1">
+      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10" Grid.Row="1" Grid.Column="0" TextAlignment="Left"/>
+      <loc:CopyPasteTextBox Text="{Binding IdentityName}" Name="txtIdentityName" Margin="10" Grid.Row="1" Grid.Column="1">
         <i:Interaction.Behaviors>
           <behaviors:FocusOnAttached />
         </i:Interaction.Behaviors>

--- a/SQRLDotNetClientUI/Views/NewIdentityView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewIdentityView.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using SQRLDotNetClientUI.AvaloniaExtensions;
 
 namespace SQRLDotNetClientUI.Views
 {
@@ -14,6 +15,12 @@ namespace SQRLDotNetClientUI.Views
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+
+            // This is only here because for some reason the XAML behaviour "FocusOnAttached"
+            // isn't working for this window. No clue why, probably a dumb mistake on my part.
+            // If anyone gets this working in XAML, this ugly hack can be removed!
+            this.FindControl<CopyPasteTextBox>("txtIdentityName").AttachedToVisualTree +=
+                (sender, e) => (sender as CopyPasteTextBox).Focus();
         }
     }
 }


### PR DESCRIPTION
Closes issue #66.

### Description:

This backports our new `ProgressDialog` to all views/viewmodels that have implemented their own progress displays in the past. This gets rid of a lot of XAML and boilerplate code and helps streamline the client project.

Things that I've fixed "along the way":
- Inconsistent placement of buttons: `Next` is always on the right side now, `Cancel` on the left.
- The `FocusOnAttached` behaviour isn't working for most of the views when set in XAML only, I don't know why. I've added a little code to each view's codebehind file to set the default focus to the correct control.