### PR TITLE
Turn password strength meter into a UserControl

### DIFF
--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -347,7 +347,7 @@
     { "IdentityCopiedToClipboardMessageBoxText": "Ihre Identität wurde in die Zwischenablage kopiert.\r\nSie können sie nun in einem anderen Client einfügen, um sie zu importieren.\r\nDazu benötigen Sie den Rettungscode!" },
     { "IdentityNameLabel": "Name der Identität:" },
     { "NewPasswordLabel": "Neues Passwort:" },
-    { "RetypePasswordLabel": "Passw. wiederholen:" },
+    { "RetypePasswordLabel": "Passw. wiederh.:" },
     { "RescueCodeLabel": "Rettungscode:" },
     { "ImportSetupMessage": "Geben Sie ihr Passwort und Ihren Rettungscode für die importierte Identität ein." },
     { "DecryptingBlock1Label": "Entschlüssle Block 1" },

--- a/SQRLDotNetClientUI/Models/PasswordStrengthMeter.cs
+++ b/SQRLDotNetClientUI/Models/PasswordStrengthMeter.cs
@@ -39,6 +39,11 @@ namespace SQRLDotNetClientUI.Models
         /// <param name="password"></param>
         private void CalculateResult(string password)
         {
+            // The provided password will sometimes be null when the dialog was 
+            // closed before our calc thread got a chance to do its thing, so 
+            // we need to handle this case here.
+            if (password == null) return;
+
             // This will avoid updating the UI too often on quick password input
             for (int i = 0; i < 10; i++)
             {
@@ -46,8 +51,8 @@ namespace SQRLDotNetClientUI.Models
                 if (_cts.IsCancellationRequested) return;
             }
 
+            // Now we should be good to calculate
             PasswordStrengthResult result = new PasswordStrengthResult();
-
             result.PasswordLength = password.Length;
 
             if (result.PasswordLength > PW_MIN_LENGTH)

--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -65,7 +65,7 @@
     <AvaloniaResource Remove="Views\MessageBox.xaml" />
     <AvaloniaResource Remove="Views\NewIdentityVerifyView.xaml" />
     <AvaloniaResource Remove="Views\NewIdentityView.xaml" />
-    <AvaloniaResource Remove="Views\PasswordStrengthMeter.xaml" />
+    <AvaloniaResource Remove="Views\NewPasswordWidget.xaml" />
     <AvaloniaResource Remove="Views\ProgressDialog.xaml" />
     <AvaloniaResource Remove="Views\ReKeyView.xaml" />
     <AvaloniaResource Remove="Views\SelectIdentityDialogView.xaml" />
@@ -108,7 +108,7 @@
     <None Remove="Views\MessageBox.xaml" />
     <None Remove="Views\NewIdentityVerifyView.xaml" />
     <None Remove="Views\NewIdentityView.xaml" />
-    <None Remove="Views\PasswordStrengthMeter.xaml" />
+    <None Remove="Views\NewPasswordWidget.xaml" />
     <None Remove="Views\ProgressDialog.xaml" />
     <None Remove="Views\ReKeyView.xaml" />
     <None Remove="Views\SelectIdentityDialogView.xaml" />
@@ -234,6 +234,9 @@
     <Compile Update="Views\ChangePasswordView.xaml.cs">
       <DependentUpon>ChangePasswordView.xaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\NewPasswordWidget.xaml.cs">
+      <DependentUpon>NewPasswordWidget.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />
@@ -260,6 +263,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\ReKeyView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Views\NewPasswordWidget.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
@@ -64,15 +64,15 @@ namespace SQRLDotNetClientUI.ViewModels
             set => this.RaiseAndSetIfChanged(ref _newPassword, value);
         }
 
-        private string _newPasswordVerify = "";
+        private string _newPasswordVerification = "";
 
         /// <summary>
         /// The verification of the new password entered by the user.
         /// </summary>
-        public string NewPasswordVerify
+        public string NewPasswordVerification
         {
-            get => _newPasswordVerify;
-            set => this.RaiseAndSetIfChanged(ref _newPasswordVerify, value);
+            get => _newPasswordVerification;
+            set => this.RaiseAndSetIfChanged(ref _newPasswordVerification, value);
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
@@ -15,6 +15,10 @@ namespace SQRLDotNetClientUI.ViewModels
     class ChangePasswordViewModel : ViewModelBase
     {
         private bool _canSave = true;
+        private bool _passwordsMatch = true;
+        private string _password = "";
+        private string _newPassword = "";
+        private string _newPasswordVerification = "";
 
         /// <summary>
         /// Gets or sets if its possible to hit the "OK" button on 
@@ -25,8 +29,6 @@ namespace SQRLDotNetClientUI.ViewModels
             get => _canSave;
             set => this.RaiseAndSetIfChanged(ref _canSave, value);
         }
-
-        private bool _passwordsMatch = true;
 
         /// <summary>
         /// Gets or sets if the new password and the password 
@@ -42,8 +44,6 @@ namespace SQRLDotNetClientUI.ViewModels
             }
         }
 
-        private string _password = "";
-
         /// <summary>
         /// The current password entered by the user.
         /// </summary>
@@ -53,8 +53,6 @@ namespace SQRLDotNetClientUI.ViewModels
             set => this.RaiseAndSetIfChanged(ref _password, value);
         }
 
-        private string _newPassword = "";
-
         /// <summary>
         /// The new password entered by the user.
         /// </summary>
@@ -63,8 +61,6 @@ namespace SQRLDotNetClientUI.ViewModels
             get => _newPassword;
             set => this.RaiseAndSetIfChanged(ref _newPassword, value);
         }
-
-        private string _newPasswordVerification = "";
 
         /// <summary>
         /// The verification of the new password entered by the user.
@@ -76,7 +72,7 @@ namespace SQRLDotNetClientUI.ViewModels
         }
 
         /// <summary>
-        /// Creates a new <c>ChangePasswordViewModel</c> instance, and sets the
+        /// Creates a new <c>ChangePasswordViewModel</c> instance and sets the
         /// dialog's window title.
         /// </summary>
         public ChangePasswordViewModel()

--- a/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
@@ -1,8 +1,4 @@
-﻿using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Media;
-using Avalonia.Threading;
-using ReactiveUI;
+﻿using ReactiveUI;
 using Serilog;
 using SQRLDotNetClientUI.Models;
 using SQRLDotNetClientUI.Views;
@@ -12,84 +8,82 @@ using System.Collections.Generic;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
+    /// <summary>
+    /// A view model providing application logic for the 
+    /// <c>ChangePasswordView</c> screeen.
+    /// </summary>
     class ChangePasswordViewModel : ViewModelBase
     {
-        private static IBrush BRUSH_POOR = new SolidColorBrush(new Color(0xFF, 0xF0, 0x80, 0x80));
-        private static IBrush BRUSH_MEDIUM = new SolidColorBrush(new Color(0xFF, 0xFF, 0xFA, 0xCD));
-        private static IBrush BRUSH_GOOD = new SolidColorBrush(new Color(0xFF, 0x32, 0xCD, 0x32));
+        private bool _canSave = true;
 
-        private PasswordStrengthMeter _pwdStrengthMeter = new PasswordStrengthMeter();
+        /// <summary>
+        /// Gets or sets if its possible to hit the "OK" button on 
+        /// the dialog to save the newly set password.
+        /// </summary>
+        public bool CanSave
+        {
+            get => _canSave;
+            set => this.RaiseAndSetIfChanged(ref _canSave, value);
+        }
 
+        private bool _passwordsMatch = true;
+
+        /// <summary>
+        /// Gets or sets if the new password and the password 
+        /// verification are equal.
+        /// </summary>
+        public bool PasswordsMatch
+        {
+            get => _passwordsMatch;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _passwordsMatch, value);
+                this.CanSave = value;
+            }
+        }
+
+        private string _password = "";
+
+        /// <summary>
+        /// The current password entered by the user.
+        /// </summary>
+        public string Password
+        {
+            get => _password;
+            set => this.RaiseAndSetIfChanged(ref _password, value);
+        }
+
+        private string _newPassword = "";
+
+        /// <summary>
+        /// The new password entered by the user.
+        /// </summary>
+        public string NewPassword
+        {
+            get => _newPassword;
+            set => this.RaiseAndSetIfChanged(ref _newPassword, value);
+        }
+
+        private string _newPasswordVerify = "";
+
+        /// <summary>
+        /// The verification of the new password entered by the user.
+        /// </summary>
+        public string NewPasswordVerify
+        {
+            get => _newPasswordVerify;
+            set => this.RaiseAndSetIfChanged(ref _newPasswordVerify, value);
+        }
+
+        /// <summary>
+        /// Creates a new <c>ChangePasswordViewModel</c> instance, and sets the
+        /// dialog's window title.
+        /// </summary>
         public ChangePasswordViewModel()
         {
             this.Title = _loc.GetLocalizationValue("ChangePasswordDialogTitle");
             if (_identityManager.CurrentIdentity != null) 
                 this.Title += " (" + _identityManager.CurrentIdentity.IdentityName + ")";
-
-            this.PasswordStrength = 0;
-            _pwdStrengthMeter.ScoreUpdated += PaswordStrengthScoreUpdated;
-
-            this.WhenAnyValue(x => x.NewPassword).Subscribe(x =>
-            {
-                _pwdStrengthMeter.Update(x);
-                CheckPasswordVerification();
-            });
-            this.WhenAnyValue(x => x.NewPasswordVerify).Subscribe(x => CheckPasswordVerification());
-        }
-
-        /// <summary>
-        /// Gets called if the <c>PasswordStrengthMeter</c> has calculated a new
-        /// password strength rating.
-        /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void PaswordStrengthScoreUpdated(object sender, ScoreUpdatedEventArgs e)
-        {
-            Dispatcher.UIThread.Post(() =>
-            {
-                string ratingText = _loc.GetLocalizationValue("PasswordStrength") + ": ";
-
-                switch (e.Score.Rating)
-                {
-                    case PasswordRating.POOR:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingPoor");
-                        this.PasswordRatingColor = BRUSH_POOR;
-                        break;
-
-                    case PasswordRating.MEDIUM:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingMedium");
-                        this.PasswordRatingColor = BRUSH_MEDIUM ;
-                        break;
-
-                    case PasswordRating.GOOD:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingGood");
-                        this.PasswordRatingColor = BRUSH_GOOD;
-                        break;
-                }
-
-                this.UppercaseIndicatorColor = e.Score.UppercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.LowercaseIndicatorColor = e.Score.LowercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.DigitsIndicatorColor = e.Score.DigitsUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.SymbolsIndicatorColor = e.Score.SymbolsUsed ? BRUSH_GOOD : BRUSH_POOR;
-
-                this.PasswordStrengthRating = ratingText;
-                this.PasswordStrength = (double)e.Score.StrengthPoints;
-            });
-
-            
-        }
-
-        /// <summary>
-        /// Checks if the password verification matches the new password
-        /// and enables/disables UI controls accordingly.
-        /// </summary>
-        private void CheckPasswordVerification()
-        {
-            if (!string.IsNullOrEmpty(this.NewPassword) && this.NewPassword == this.NewPasswordVerify)
-            {
-                this.CanSave = true;
-            }
-            else this.CanSave = false;
         }
 
         /// <summary>
@@ -151,90 +145,6 @@ namespace SQRLDotNetClientUI.ViewModels
 
             CanSave = true;
             Close();
-        }
-
-        private bool _canSave = true;
-        public bool CanSave
-        {
-            get => _canSave;
-            set => this.RaiseAndSetIfChanged(ref _canSave, value);
-        }
-
-        private string _password = "";
-        public string Password
-        {
-            get => _password;
-            set => this.RaiseAndSetIfChanged(ref _password, value);
-        }
-
-        private string _newPassword = "";
-        public string NewPassword
-        {
-            get => _newPassword;
-            set => this.RaiseAndSetIfChanged(ref _newPassword, value);
-        }
-
-        private string _newPasswordVerify = "";
-        public string NewPasswordVerify
-        {
-            get => _newPasswordVerify;
-            set => this.RaiseAndSetIfChanged(ref _newPasswordVerify, value);
-        }
-
-        private double _passwordStrength = 0;
-        public double PasswordStrength
-        {
-            get => _passwordStrength;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrength, value);
-        }
-
-        private IBrush _passwordRatingColor = Brushes.Crimson;
-        public IBrush PasswordRatingColor
-        {
-            get => _passwordRatingColor;
-            set => this.RaiseAndSetIfChanged(ref _passwordRatingColor, value);
-        }
-
-        private IBrush _uppercaseIndicatorColor = Brushes.Crimson;
-        public IBrush UppercaseIndicatorColor
-        {
-            get => _uppercaseIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _uppercaseIndicatorColor, value);
-        }
-
-        private IBrush _lowercaseIndicatorColor = Brushes.Crimson;
-        public IBrush LowercaseIndicatorColor
-        {
-            get => _lowercaseIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _lowercaseIndicatorColor, value);
-        }
-
-        private IBrush _digitsIndicatorColor = Brushes.Crimson;
-        public IBrush DigitsIndicatorColor
-        {
-            get => _digitsIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _digitsIndicatorColor, value);
-        }
-
-        private IBrush _symbolsIndicatorColor = Brushes.Crimson;
-        public IBrush SymbolsIndicatorColor
-        {
-            get => _symbolsIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _symbolsIndicatorColor, value);
-        }
-
-        private string _passwordStrengthRating = "";
-        public string PasswordStrengthRating
-        {
-            get => _passwordStrengthRating;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrengthRating, value);
-        }
-
-        private double _passwordStrengthMax = PasswordStrengthMeter.STRENGTH_POINTS_MIN_GOOD;
-        public double PasswordStrengthMax
-        {
-            get => _passwordStrengthMax;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrengthMax, value);
         }
     }
 }

--- a/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
@@ -9,41 +9,121 @@ using System.Threading.Tasks;
 
 namespace SQRLDotNetClientUI.ViewModels
 { 
+    /// <summary>
+    /// A viewmodel providing application logic for <c>ImportIdentitySetupView</c>.
+    /// </summary>
     public class ImportIdentitySetupViewModel : ViewModelBase
     {
-        public SQRLIdentity Identity { get; set; }
-        public string IdentityName { get; set; } = "";
-        public string RescueCode { get; set; }
-        public string NewPassword { get; set; }
-        public string NewPasswordVerify { get; set; }
+        private bool _canSave = true;
+        private bool _passwordsMatch = true;
+        private string _newPassword = "";
+        private string _newPasswordVerification = "";
 
+        /// <summary>
+        /// The SQRL identity to be imported.
+        /// </summary>
+        public SQRLIdentity Identity { get; set; }
+
+        /// <summary>
+        /// The identity name entered by the user.
+        /// </summary>
+        public string IdentityName { get; set; } = "";
+
+        /// <summary>
+        /// The rescue code entered by the user.
+        /// </summary>
+        public string RescueCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets if its possible to hit the "OK" button on 
+        /// the dialog to actually import the identity.
+        /// </summary>
+        public bool CanSave
+        {
+            get => _canSave;
+            set => this.RaiseAndSetIfChanged(ref _canSave, value);
+        }
+
+        /// <summary>
+        /// Gets or sets if the new password and the password 
+        /// verification are equal.
+        /// </summary>
+        public bool PasswordsMatch
+        {
+            get => _passwordsMatch;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _passwordsMatch, value);
+                this.CanSave = value;
+            }
+        }
+
+        /// <summary>
+        /// The new password entered by the user.
+        /// </summary>
+        public string NewPassword
+        {
+            get => _newPassword;
+            set => this.RaiseAndSetIfChanged(ref _newPassword, value);
+        }
+
+        /// <summary>
+        /// The verification of the new password entered by the user.
+        /// </summary>
+        public string NewPasswordVerification
+        {
+            get => _newPasswordVerification;
+            set => this.RaiseAndSetIfChanged(ref _newPasswordVerification, value);
+        }
+
+        /// <summary>
+        /// Creates a new <c>ImportIdentitySetupViewModel</c> instance.
+        /// </summary>
         public ImportIdentitySetupViewModel()
         {
             Init();
         }
+
+        /// <summary>
+        /// Creates a new <c>ImportIdentitySetupViewModel</c> instance
+        /// and sets the identity to be imorted.
+        /// </summary>
+        /// <param name="identity">The identity to be imported.</param>
         public ImportIdentitySetupViewModel(SQRLIdentity identity)
         {
             Init();
             this.Identity = identity;
         }
 
+        /// <summary>
+        /// Used by the c-tors to initialize stuff.
+        /// </summary>
         private void Init()
         {
             this.Title = _loc.GetLocalizationValue("ImportIdentitySetupWindowTitle");
         }
 
+        /// <summary>
+        /// Takes the user back to the previous screen.
+        /// </summary>
         public void Previous()
         {
             ((MainWindowViewModel)_mainWindow.DataContext).Content = 
                 ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
         }
 
+        /// <summary>
+        /// Takes the user back to the main screen.
+        /// </summary>
         public void Cancel()
         {
             ((MainWindowViewModel)_mainWindow.DataContext).Content =
                 ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
         }
 
+        /// <summary>
+        /// Verifies and actually imports the identity.
+        /// </summary>
         public async void VerifyAndImportIdentity()
         {
             var progressBlock1 = new Progress<KeyValuePair<int, string>>();

--- a/SQRLDotNetClientUI/ViewModels/NewIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/NewIdentityViewModel.cs
@@ -7,63 +7,113 @@ using System.Collections.Generic;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
+    /// <summary>
+    /// A view model providing application logic for <c>NewIdentityView</c>.
+    /// </summary>
     public class NewIdentityViewModel: ViewModelBase
     {
+        private bool _canSave = true;
+        private bool _passwordsMatch = true;
+        private string _newPassword = "";
+        private string _newPasswordVerification = "";
+
+        /// <summary>
+        /// The rescue code which was created for the new identity.
+        /// </summary>
+        public string RescueCode { get; }
+
+        /// <summary>
+        /// Gets or sets if its possible to hit the "OK" button on 
+        /// the dialog to actually create the identity.
+        /// </summary>
+        public bool CanSave
+        {
+            get => _canSave;
+            set => this.RaiseAndSetIfChanged(ref _canSave, value);
+        }
+
+        /// <summary>
+        /// Gets or sets if the new password and the password 
+        /// verification are equal.
+        /// </summary>
+        public bool PasswordsMatch
+        {
+            get => _passwordsMatch;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _passwordsMatch, value);
+                this.CanSave = value;
+            }
+        }
+
+        /// <summary>
+        /// The new password entered by the user.
+        /// </summary>
+        public string NewPassword
+        {
+            get => _newPassword;
+            set => this.RaiseAndSetIfChanged(ref _newPassword, value);
+        }
+
+        /// <summary>
+        /// The verification of the new password entered by the user.
+        /// </summary>
+        public string NewPasswordVerification
+        {
+            get => _newPasswordVerification;
+            set => this.RaiseAndSetIfChanged(ref _newPasswordVerification, value);
+        }
+
+        /// <summary>
+        /// The identity name that was entered by the user.
+        /// </summary>
+        public string IdentityName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Creates a new <c>NewIdentityViewModel</c> intance.
+        /// </summary>
         public NewIdentityViewModel()
         {
             this.Title = _loc.GetLocalizationValue("NewIdentityWindowTitle");
             this.RescueCode = SQRL.FormatRescueCodeForDisplay(SQRL.CreateRescueCode());
         }
 
-        public string RescueCode { get; }
-
-        public string Password { get; set; } = string.Empty;
-
-        public string PasswordConfirm { get; set; } = string.Empty;
-
-        public string IdentityName { get; set; } = string.Empty;
-
+        /// <summary>
+        /// Actually generates the new identity.
+        /// </summary>
         public async void GenerateNewIdentity()
         {
-            if (this.Password.Equals(this.PasswordConfirm))
+            SQRLIdentity newId = new SQRLIdentity(this.IdentityName);
+            byte[] iuk = SQRL.CreateIUK();
+            byte[] imk = SQRL.CreateIMK(iuk);
+
+            var progressBlock1 = new Progress<KeyValuePair<int, string>>();
+            var progressBlock2 = new Progress<KeyValuePair<int, string>>();
+            var progressDialog = new ProgressDialog(new List<Progress<KeyValuePair<int, string>>>() {
+                progressBlock1, progressBlock2});
+            _ = progressDialog.ShowDialog(_mainWindow);
+
+            newId = SQRL.GenerateIdentityBlock0(imk, newId);
+            newId = await SQRL.GenerateIdentityBlock1(iuk, this.NewPassword, newId, progressBlock1);
+
+            if (newId.Block1 != null)
             {
-
-                SQRLIdentity newId = new SQRLIdentity(this.IdentityName);
-                byte[] iuk = SQRL.CreateIUK();
-                byte[] imk = SQRL.CreateIMK(iuk);
-
-                var progressBlock1 = new Progress<KeyValuePair<int, string>>();
-                var progressBlock2 = new Progress<KeyValuePair<int, string>>();
-                var progressDialog = new ProgressDialog(new List<Progress<KeyValuePair<int, string>>>() {
-                    progressBlock1, progressBlock2});
-                _ = progressDialog.ShowDialog(_mainWindow);
-
-                newId = SQRL.GenerateIdentityBlock0(imk, newId);
-                newId = await SQRL.GenerateIdentityBlock1(iuk, this.Password, newId, progressBlock1);
-
-                if (newId.Block1 != null)
+                newId = await SQRL.GenerateIdentityBlock2(iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
+                if (newId.Block2 != null)
                 {
-                    newId = await SQRL.GenerateIdentityBlock2(iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
-                    if (newId.Block2 != null)
-                    {
-                        progressDialog.Close();
+                    progressDialog.Close();
 
-                        ((MainWindowViewModel)_mainWindow.DataContext).Content = 
-                            new NewIdentityVerifyViewModel(newId, this.Password);
-                    }
+                    ((MainWindowViewModel)_mainWindow.DataContext).Content = 
+                        new NewIdentityVerifyViewModel(newId, this.NewPassword);
                 }
-                progressDialog.Close();
             }
-            else
-            {
-                await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                    _loc.GetLocalizationValue("PasswordsDontMatchErrorMessage"),
-                    MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
-            }
+            progressDialog.Close();
         }
 
-        public  void Cancel()
+        /// <summary>
+        /// Displays the previous screen.
+        /// </summary>
+        public void Cancel()
         {
             ((MainWindowViewModel)_mainWindow.DataContext).Content = 
                 ((MainWindowViewModel)_mainWindow.DataContext).PriorContent;

--- a/SQRLDotNetClientUI/ViewModels/ReKeyViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ReKeyViewModel.cs
@@ -1,195 +1,89 @@
 ﻿using Avalonia.Controls;
-using Avalonia.Media;
-using Avalonia.Threading;
 using ReactiveUI;
-using SQRLDotNetClientUI.Models;
 using SQRLDotNetClientUI.Views;
 using SQRLUtilsLib;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
     /// <summary>
-    /// ViewModel used for re-keying the current Identity Key
+    /// ViewModel used for re-keying the current identity.
     /// </summary>
     public class ReKeyViewModel : ViewModelBase
     {
-        private static IBrush BRUSH_POOR = new SolidColorBrush(new Color(0xFF, 0xF0, 0x80, 0x80));
-        private static IBrush BRUSH_MEDIUM = new SolidColorBrush(new Color(0xFF, 0xFF, 0xFA, 0xCD));
-        private static IBrush BRUSH_GOOD = new SolidColorBrush(new Color(0xFF, 0x32, 0xCD, 0x32));
         private bool _canSave = true;
+        private bool _passwordsMatch = true;
+        private string _password = "";
+        private string _newPassword = "";
+        private string _newPasswordVerification = "";
+
+        /// <summary>
+        /// Gets or sets if its possible to hit the "OK" button on 
+        /// the dialog to actually rekey the identity.
+        /// </summary>
         public bool CanSave
         {
             get => _canSave;
             set => this.RaiseAndSetIfChanged(ref _canSave, value);
         }
 
-        private string _password = "";
+        /// <summary>
+        /// Gets or sets if the new password and the password 
+        /// verification are equal.
+        /// </summary>
+        public bool PasswordsMatch
+        {
+            get => _passwordsMatch;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _passwordsMatch, value);
+                this.CanSave = value;
+            }
+        }
+
+        /// <summary>
+        /// The current password entered by the user.
+        /// </summary>
         public string Password
         {
             get => _password;
             set => this.RaiseAndSetIfChanged(ref _password, value);
         }
 
-        private string _newPassword = "";
+        /// <summary>
+        /// The new password entered by the user.
+        /// </summary>
         public string NewPassword
         {
             get => _newPassword;
             set => this.RaiseAndSetIfChanged(ref _newPassword, value);
         }
 
-        private string _newPasswordVerify = "";
-        public string NewPasswordVerify
+        /// <summary>
+        /// The verification of the new password entered by the user.
+        /// </summary>
+        public string NewPasswordVerification
         {
-            get => _newPasswordVerify;
-            set => this.RaiseAndSetIfChanged(ref _newPasswordVerify, value);
-        }
-
-        private double _passwordStrength = 0;
-        public double PasswordStrength
-        {
-            get => _passwordStrength;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrength, value);
-        }
-
-        private IBrush _passwordRatingColor = Brushes.Crimson;
-        public IBrush PasswordRatingColor
-        {
-            get => _passwordRatingColor;
-            set => this.RaiseAndSetIfChanged(ref _passwordRatingColor, value);
-        }
-
-        private IBrush _uppercaseIndicatorColor = Brushes.Crimson;
-        public IBrush UppercaseIndicatorColor
-        {
-            get => _uppercaseIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _uppercaseIndicatorColor, value);
-        }
-
-        private IBrush _lowercaseIndicatorColor = Brushes.Crimson;
-        public IBrush LowercaseIndicatorColor
-        {
-            get => _lowercaseIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _lowercaseIndicatorColor, value);
-        }
-
-        private IBrush _digitsIndicatorColor = Brushes.Crimson;
-        public IBrush DigitsIndicatorColor
-        {
-            get => _digitsIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _digitsIndicatorColor, value);
-        }
-
-        private IBrush _symbolsIndicatorColor = Brushes.Crimson;
-        public IBrush SymbolsIndicatorColor
-        {
-            get => _symbolsIndicatorColor;
-            set => this.RaiseAndSetIfChanged(ref _symbolsIndicatorColor, value);
-        }
-
-        private string _passwordStrengthRating = "";
-        public string PasswordStrengthRating
-        {
-            get => _passwordStrengthRating;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrengthRating, value);
-        }
-
-        private double _passwordStrengthMax = PasswordStrengthMeter.STRENGTH_POINTS_MIN_GOOD;
-        public double PasswordStrengthMax
-        {
-            get => _passwordStrengthMax;
-            set => this.RaiseAndSetIfChanged(ref _passwordStrengthMax, value);
-        }
-        private PasswordStrengthMeter _pwdStrengthMeter = new PasswordStrengthMeter();
-        public ReKeyViewModel()
-        {
-            Init();
-        }
-        private string _ReKeyIdentityExplanation;
-        public string ReKeyIdentityExplanation
-        {
-            get => _ReKeyIdentityExplanation;
-            set => this.RaiseAndSetIfChanged(ref _ReKeyIdentityExplanation, value);
+            get => _newPasswordVerification;
+            set => this.RaiseAndSetIfChanged(ref _newPasswordVerification, value);
         }
 
         /// <summary>
-        /// Called from Constructor(s) to initialize various things
+        /// Creates a new <c>ReKeyViewModel</c> instance.
         /// </summary>
-        public void Init()
+        public ReKeyViewModel()
         {
             if (_loc != null)
             {
-                this.Title = string.Format(_loc.GetLocalizationValue("ReKeyIdentityTitle"), _identityManager.CurrentIdentity.IdentityName);
-                
+                this.Title = string.Format(_loc.GetLocalizationValue("ReKeyIdentityTitle"),
+                    _identityManager.CurrentIdentity.IdentityName);
             }
-            this.PasswordStrength = 0;
-            _pwdStrengthMeter.ScoreUpdated += PaswordStrengthScoreUpdated;
-
-            this.WhenAnyValue(x => x.NewPassword).Subscribe(x =>
-            {
-                _pwdStrengthMeter.Update(x);
-                CheckPasswordVerification();
-            });
-            this.WhenAnyValue(x => x.NewPasswordVerify).Subscribe(x => CheckPasswordVerification());
         }
 
         /// <summary>
-        /// Gets called if the <c>PasswordStrengthMeter</c> has calculated a new
-        /// password strength rating.
+        /// Displays the main screen.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
-        private void PaswordStrengthScoreUpdated(object sender, ScoreUpdatedEventArgs e)
-        {
-            Dispatcher.UIThread.Post(() =>
-            {
-                string ratingText = _loc.GetLocalizationValue("PasswordStrength") + ": ";
-
-                switch (e.Score.Rating)
-                {
-                    case PasswordRating.POOR:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingPoor");
-                        this.PasswordRatingColor = BRUSH_POOR;
-                        break;
-
-                    case PasswordRating.MEDIUM:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingMedium");
-                        this.PasswordRatingColor = BRUSH_MEDIUM;
-                        break;
-
-                    case PasswordRating.GOOD:
-                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingGood");
-                        this.PasswordRatingColor = BRUSH_GOOD;
-                        break;
-                }
-
-                this.UppercaseIndicatorColor = e.Score.UppercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.LowercaseIndicatorColor = e.Score.LowercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.DigitsIndicatorColor = e.Score.DigitsUsed ? BRUSH_GOOD : BRUSH_POOR;
-                this.SymbolsIndicatorColor = e.Score.SymbolsUsed ? BRUSH_GOOD : BRUSH_POOR;
-
-                this.PasswordStrengthRating = ratingText;
-                this.PasswordStrength = (double)e.Score.StrengthPoints;
-            });
-
-
-        }
-
-        /// <summary>
-        /// Checks if the password verification matches the new password
-        /// and enables/disables UI controls accordingly.
-        /// </summary>
-        private void CheckPasswordVerification()
-        {
-            if (!string.IsNullOrEmpty(this.NewPassword) && this.NewPassword == this.NewPasswordVerify)
-            {
-                this.CanSave = true;
-            }
-            else this.CanSave = false;
-        }
-
         public void Cancel()
         {
             ((MainWindowViewModel)_mainWindow.DataContext).Content =
@@ -197,7 +91,7 @@ namespace SQRLDotNetClientUI.ViewModels
         }
 
         /// <summary>
-        /// Runs the Re-Key Logic
+        /// Runs the Re-Key logic.
         /// </summary>
         public async void Next()
         {
@@ -207,11 +101,11 @@ namespace SQRLDotNetClientUI.ViewModels
             //Dialog Box used to capture the user's current Rescue Code
             InputSecretDialogView rescueCodeDlg = new InputSecretDialogView(SecretType.RescueCode);
             rescueCodeDlg.WindowStartupLocation = WindowStartupLocation.CenterOwner;
-            string rescueCode = await rescueCodeDlg.ShowDialog<string>(
-                _mainWindow);
+            string rescueCode = await rescueCodeDlg.ShowDialog<string>(_mainWindow);
 
             //List of Progress Reporters to be used during the re-key process (progress bar magic)
-            var  progressList = new List<Progress<KeyValuePair<int, string>>>(){ new Progress<KeyValuePair<int, string>>(),new Progress<KeyValuePair<int, string>>() };
+            var  progressList = new List<Progress<KeyValuePair<int, string>>>() { 
+                new Progress<KeyValuePair<int, string>>(), new Progress<KeyValuePair<int, string>>() };
 
             //Progress Dialog will show our "Progress" as the Identity is Decrypted, and Re-Encrypted for Rekey
             var progressDialog = new ProgressDialog(progressList);
@@ -220,15 +114,19 @@ namespace SQRLDotNetClientUI.ViewModels
             _ = progressDialog.ShowDialog(_mainWindow);
 
             //Actually do the Re-Key Work
-            var result = await SQRL.RekeyIdentity(_identityManager.CurrentIdentity, SQRL.CleanUpRescueCode(rescueCode), NewPassword, progressList[0],progressList[1]);
+            var result = await SQRL.RekeyIdentity(_identityManager.CurrentIdentity, SQRL.CleanUpRescueCode(rescueCode), 
+                NewPassword, progressList[0], progressList[1]);
+
             if(!result.Success)
             {
                 progressDialog.Close();
+
                 //Fail bad rescue code (something went wrong...) try again?
                 var answer = await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                                   _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
-                                                                   MessageBoxSize.Small, MessageBoxButtons.YesNo, MessageBoxIcons.ERROR)
-                                                                   .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                    _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
+                    MessageBoxSize.Small, MessageBoxButtons.YesNo, MessageBoxIcons.ERROR)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+
                 if (answer == MessagBoxDialogResult.YES)
                 {
                     goto RetryRescueCode; //Go back up and re-do it all, this time with passion!
@@ -238,21 +136,18 @@ namespace SQRLDotNetClientUI.ViewModels
             {
                 progressDialog.Close();
 
-                //This label is used to re-share the new rescue code if it was copied incorrectly.
-                CopiedWrong:
+            //This label is used to re-share the new rescue code if it was copied incorrectly.
+            CopiedWrong:
                 //Message Box which displays the new Rescue Code to the user
                 await new Views.MessageBox(_loc.GetLocalizationValue("IdentityReKeyNewCode"),
-                                                                   string.Format(_loc.GetLocalizationValue("IdentityReKeyMessage"),SQRL.FormatRescueCodeForDisplay((result.NewRescueCode))),
-                                                                   MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.OK)
-                                                                   .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                    string.Format(_loc.GetLocalizationValue("IdentityReKeyMessage"), SQRL.FormatRescueCodeForDisplay(result.NewRescueCode)),
+                    MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.OK)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
 
                 //Ask the user to re-type their New Rescue Code to verify that they copied it correctly.
-                rescueCodeDlg = new InputSecretDialogView(SecretType.RescueCode)
-                {
-                    WindowStartupLocation = WindowStartupLocation.CenterOwner
-                };
-                rescueCode = await rescueCodeDlg.ShowDialog<string>(
-                    _mainWindow);
+                rescueCodeDlg = new InputSecretDialogView(SecretType.RescueCode);
+                rescueCodeDlg.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                rescueCode = await rescueCodeDlg.ShowDialog<string>(_mainWindow);
                 
                 //New progress dialog for the verification step
                 progressDialog = new ProgressDialog(progressList[0]);
@@ -261,37 +156,40 @@ namespace SQRLDotNetClientUI.ViewModels
 
                 //Decrypt Block 2 to verify they copied their rescue code correctly.
                 var block2Results = await SQRL.DecryptBlock2(result.RekeyedIdentity, rescueCode, progressList[0]);
-                if (block2Results.DecryptionSucceeded) //All Good , All Done
+                if (block2Results.DecryptionSucceeded) //All Good, All Done
                 {
                     progressDialog.Close();
                     _identityManager.DeleteCurrentIdentity();
                     _identityManager.ImportIdentity(result.RekeyedIdentity, true);
-                    ((MainWindowViewModel)_mainWindow.DataContext).Content = ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
+
+                    // Display the main screen
+                    Cancel();
                 }
                 else //Fail bad rescue code... try again?
                 {
                     progressDialog.Close();
                     var answer = await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                                   _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
-                                                                   MessageBoxSize.Small, MessageBoxButtons.YesNo, MessageBoxIcons.ERROR)
-                                                                   .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                        _loc.GetLocalizationValue("InvalidRescueCodeMessage"),
+                        MessageBoxSize.Small, MessageBoxButtons.YesNo, MessageBoxIcons.ERROR)
+                        .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+
                     if (answer == MessagBoxDialogResult.YES)
                     {
                         goto CopiedWrong; //Try Again
                     }
                     else //Abort the whole thing
                     {
-                        _=await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
-                                                                   _loc.GetLocalizationValue("IdentityReKeyFailed"),
-                                                                   MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
-                                                                   .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                        _ = await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
+                            _loc.GetLocalizationValue("IdentityReKeyFailed"),
+                            MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                            .ShowDialog<MessagBoxDialogResult>(_mainWindow);
                     }
                 }
                 
             }
-             ((MainWindowViewModel)_mainWindow.DataContext).Content = ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
+
+            // Display the main screen
+            Cancel();
         }
     }
-
-
 }

--- a/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
+++ b/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
@@ -39,7 +39,7 @@
 
       </Grid>
 
-      <v:NewPasswordWidget Margin="10" />
+      <v:NewPasswordWidget Margin="10" PasswordsMatch="{Binding PasswordsMatch}" />
 
     </StackPanel>
 

--- a/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
+++ b/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
@@ -6,80 +6,49 @@
              xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:Class="SQRLDotNetClientUI.Views.ChangePasswordView">
 
-  <StackPanel>
+  <DockPanel LastChildFill="False">
+    <StackPanel DockPanel.Dock="Top">
 
-    <Grid ShowGridLines="False">
-      <Grid.ColumnDefinitions>
-        <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="250"/>
-      </Grid.ColumnDefinitions>
-      <Grid.RowDefinitions>
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-      </Grid.RowDefinitions>
+      <Grid ShowGridLines="False">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="100"/>
+          <ColumnDefinition Width="250"/>
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+          <RowDefinition />
+          <RowDefinition />
+        </Grid.RowDefinitions>
 
-      <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right"
-             VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
+        <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right"
+               VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
 
-      <TextBlock Margin="10" Text="{loc:Localization NewPasswordMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" 
-                 Grid.Column="1" Grid.ColumnSpan="2"/>
+        <TextBlock Margin="10" Text="{loc:Localization NewPasswordMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" 
+                   Grid.Column="1" Grid.ColumnSpan="2"/>
 
-      <TextBlock Margin="10" Text="{loc:Localization PasswordLabel}" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
-      <loc:CopyPasteTextBox Name="txtPassword" Margin="10" Text="{Binding Password}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" PasswordChar="*" Grid.Row="1" Grid.Column="1">
-        <i:Interaction.Behaviors>
-          <behaviors:FocusOnAttached />
-        </i:Interaction.Behaviors>
-      </loc:CopyPasteTextBox>
+        <TextBlock Margin="10" Text="{loc:Localization PasswordLabel}" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
+        <loc:CopyPasteTextBox Name="txtPassword" Margin="10" Text="{Binding Password}" Width="250" HorizontalAlignment="Left" 
+                              VerticalAlignment="Top" PasswordChar="*" Grid.Row="1" Grid.Column="1">
+          <i:Interaction.Behaviors>
+            <behaviors:FocusOnAttached />
+          </i:Interaction.Behaviors>
+        </loc:CopyPasteTextBox>
 
-      <TextBlock Margin="10" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="2" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" PasswordChar="*" Grid.Row="2" Grid.Column="1"/>
+      </Grid>
 
-      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
-                            PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
+      <v:NewPasswordWidget Margin="10" />
 
-      <ProgressBar IsIndeterminate="False" Value="{Binding PasswordStrength}" Maximum="{Binding PasswordStrengthMax}" HorizontalAlignment="Left"
-                   Minimum="0" IsEnabled="true" MinHeight="4" Height="4" Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,10,10,5" Width="370"/>
+    </StackPanel>
 
-      <Panel Margin="10,0,10,5" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Width="370" Background="{Binding PasswordRatingColor}">
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-          <TextBlock Margin="10,5,10,5" FontSize="12" Text="{Binding PasswordStrengthRating}" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
-        </StackPanel>
-      </Panel>
-
-      <Panel Margin="10,0,10,10" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Width="370">
-        <Panel.Resources>
-          <loc:StringUppercaseConverter x:Key="stringUppercaseConverter" />
-        </Panel.Resources>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Right">
-          <StackPanel Orientation="Horizontal">
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding UppercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization UppercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding LowercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization LowercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal">
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding DigitsIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization DigitsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding SymbolsIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization SymbolsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          </StackPanel>
-        </StackPanel>
-      </Panel>
-
-      <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Close}" Grid.Row="7" Grid.Column="0" Width="90" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnOK}" Command="{Binding SetNewPassword}" IsEnabled="{Binding CanSave}" IsDefault="True" Margin="10" Grid.Row="7" Grid.Column="1" Width="90" HorizontalAlignment="Right"/>
-
-    </Grid>
-  </StackPanel>
-
+    <DockPanel DockPanel.Dock="Bottom" Margin="20">
+      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Close}" Width="90" DockPanel.Dock="Left" />
+      <Button Content="{loc:Localization BtnOK}" Command="{Binding SetNewPassword}" IsEnabled="{Binding CanSave}" 
+              IsDefault="True" Width="90" DockPanel.Dock="Left" HorizontalAlignment="Right" />
+    </DockPanel>
+    
+    
+  </DockPanel>
 </UserControl>

--- a/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
+++ b/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
@@ -39,7 +39,9 @@
 
       </Grid>
 
-      <v:NewPasswordWidget Margin="10" PasswordsMatch="{Binding PasswordsMatch}" />
+      <v:NewPasswordWidget Margin="10" Password="{Binding NewPassword}" 
+                           PasswordVerification="{Binding NewPasswordVerification}" 
+                           PasswordsMatch="{Binding PasswordsMatch}" />
 
     </StackPanel>
 

--- a/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
+++ b/SQRLDotNetClientUI/Views/ChangePasswordView.xaml
@@ -39,8 +39,9 @@
 
       </Grid>
 
-      <v:NewPasswordWidget Margin="10" Password="{Binding NewPassword}" 
-                           PasswordVerification="{Binding NewPasswordVerification}" 
+      <v:NewPasswordWidget Margin="10" 
+                           NewPassword="{Binding NewPassword}" 
+                           NewPasswordVerification="{Binding NewPasswordVerification}" 
                            PasswordsMatch="{Binding PasswordsMatch}" />
 
     </StackPanel>

--- a/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentitySetupView.xaml
@@ -6,23 +6,19 @@
              xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+             Width="400" Height="450"
              x:Class="SQRLDotNetClientUI.Views.ImportIdentitySetupView">
   
-  
-  <StackPanel>
-    <Grid ShowGridLines="False">
+  <DockPanel LastChildFill="False">
+    
+    <Grid DockPanel.Dock="Top" ShowGridLines="False">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="290"/>
+        <ColumnDefinition Width="250"/>
       </Grid.ColumnDefinitions>
       <Grid.RowDefinitions>
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
         <RowDefinition />
         <RowDefinition />
         <RowDefinition />
@@ -31,28 +27,30 @@
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
       
-      <TextBlock Text="{loc:Localization ImportSetupMessage}" Margin="10" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
+      <TextBlock Text="{loc:Localization ImportSetupMessage}" Margin="10" FontSize="15" TextWrapping="Wrap" 
+                 Grid.Row="0" Grid.Column="1"/>
 
-      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10" Grid.Row="1" Grid.Column="0" />
+      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10,10,0,10" Grid.Row="1" Grid.Column="0" Width="90"/>
       <loc:CopyPasteTextBox Text="{Binding IdentityName}" Name="txtIdentityName" Margin="10" Width="250" HorizontalAlignment="Left" Grid.Row="1" Grid.Column="1">
         <i:Interaction.Behaviors>
           <behaviors:FocusOnAttached />
         </i:Interaction.Behaviors>
       </loc:CopyPasteTextBox>
 
-      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
+      <TextBlock Text="{loc:Localization RescueCodeLabel}" Margin="10,10,0,10" Grid.Row="2" Grid.Column="0" Width="90"/>
       <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding RescueCode}" Width="250" HorizontalAlignment="Left" Grid.Row="2" Grid.Column="1"  />
-
-      <TextBlock Margin="10" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
-
-      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
-                            PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
-
-      <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="8" Grid.Column="0" Width="90" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnNext}" IsDefault="True" Margin="10,10,20,10" Command="{Binding VerifyAndImportIdentity}" Grid.Row="8" Grid.Column="1" Width="90" HorizontalAlignment="Right" />
-
+      
     </Grid>
-  </StackPanel>
+
+    <v:NewPasswordWidget DockPanel.Dock="Top" Margin="10"
+                         NewPassword="{Binding NewPassword}"
+                         NewPasswordVerification="{Binding NewPasswordVerification}"
+                         PasswordsMatch="{Binding PasswordsMatch}" />
+
+    <DockPanel DockPanel.Dock="Bottom" Margin="10">
+      <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Width="90" HorizontalAlignment="Left" DockPanel.Dock="Left" />
+      <Button Content="{loc:Localization BtnNext}" IsDefault="True" IsEnabled="{Binding CanSave}" Margin="10,10,20,10" Command="{Binding VerifyAndImportIdentity}" Width="90" HorizontalAlignment="Right" DockPanel.Dock="Right"/>
+    </DockPanel>
+    
+  </DockPanel>
 </UserControl>

--- a/SQRLDotNetClientUI/Views/NewIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/NewIdentityView.xaml
@@ -5,50 +5,51 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+             Width="400" 
+             Height="450"
              x:Class="SQRLDotNetClientUI.Views.NewIdentityView">  
   
-  <StackPanel>
-    <Grid>
+  <DockPanel LastChildFill="False">
+    
+    <Grid DockPanel.Dock="Top">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="100"/>
-        <ColumnDefinition Width="275"/>
+        <ColumnDefinition Width="250"/>
       </Grid.ColumnDefinitions>
       <Grid.RowDefinitions>
         <RowDefinition />
         <RowDefinition />
         <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition  />
-        <RowDefinition  />
       </Grid.RowDefinitions>
+           
+      <TextBlock Margin="10" Text="{loc:Localization NewIdentityMessage}" FontSize="12" TextWrapping="Wrap" 
+                 Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2"/>
       
-      <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
-             VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
-      <TextBlock Margin="10" Text="{loc:Localization NewIdentityMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
-      
-      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10" Grid.Row="1" Grid.Column="0" TextAlignment="Left"/>
-      <loc:CopyPasteTextBox Text="{Binding IdentityName}" Name="txtIdentityName" Margin="10" Grid.Row="1" Grid.Column="1">
+      <TextBlock Text="{loc:Localization IdentityNameLabel}" Margin="10,10,0,10" Grid.Row="1" Grid.Column="0" TextAlignment="Left" Width="90"/>
+      <loc:CopyPasteTextBox Text="{Binding IdentityName}" Name="txtIdentityName" Width="250" Margin="10" Grid.Row="1" Grid.Column="1">
         <i:Interaction.Behaviors>
           <behaviors:FocusOnAttached />
         </i:Interaction.Behaviors>
       </loc:CopyPasteTextBox>
        
-      <TextBlock Margin="10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0"/>
-      <loc:CopyPasteTextBox Margin="10"  Text="{Binding RescueCode}" Grid.Row="2" Grid.Column="1" IsReadOnly="True"  />
-       
-      <TextBlock Margin="10" Text="{loc:Localization PasswordLabel}" Grid.Row="3" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding Password}" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
-      
-      <TextBlock Margin="10" Text="{loc:Localization RetypePasswordLabel}" Grid.Row="4" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="10,0,10,20" Text="{Binding PasswordConfirm}" PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
-      
-      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Cancel}" Margin="10" Grid.Row="6" Grid.Column="0"  Width="70" HorizontalAlignment="Left" />
-      <Button Content="{loc:Localization BtnNext}" Command="{Binding GenerateNewIdentity}" IsDefault="True" Margin="10" Grid.Row="6" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
+      <TextBlock Margin="10,10,0,10" Text="{loc:Localization RescueCodeLabel}" Grid.Row="2" Grid.Column="0" Width="90"/>
+      <loc:CopyPasteTextBox Margin="10" Text="{Binding RescueCode}" Width="250" Grid.Row="2" Grid.Column="1" IsReadOnly="True"/>
       
     </Grid>
-  </StackPanel>
+
+    <v:NewPasswordWidget DockPanel.Dock="Top" Margin="10"
+                           NewPassword="{Binding NewPassword}"
+                           NewPasswordVerification="{Binding NewPasswordVerification}"
+                           PasswordsMatch="{Binding PasswordsMatch}" />
+
+    <DockPanel DockPanel.Dock="Bottom" Margin="10">
+      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Cancel}" DockPanel.Dock="Left" Margin="10" Width="70" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnNext}" Command="{Binding GenerateNewIdentity}" IsEnabled="{Binding CanSave}" IsDefault="True" Margin="10" Width="70" DockPanel.Dock="Right" HorizontalAlignment="Right" />
+    </DockPanel>
+    
+  </DockPanel>
   
 </UserControl>

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
+             Name="NewPasswordWidget"
              x:Class="SQRLDotNetClientUI.Views.NewPasswordWidget">
 
   <StackPanel Orientation="Vertical">
@@ -19,21 +20,21 @@
       </Grid.RowDefinitions>
 
       <TextBlock Margin="0" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="0" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
+      <loc:CopyPasteTextBox Text="{Binding NewPassword}" Name="txtNewPassword" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
                             PasswordChar="*" Grid.Row="0" Grid.Column="1"/>
 
       <TextBlock Margin="0,10,0,0" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="0,10,0,0" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
+      <loc:CopyPasteTextBox Margin="0,10,0,0" Text="{Binding NewPasswordVerify}" Name="txtNewPasswordVerify" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
                             PasswordChar="*" Grid.Row="1" Grid.Column="1"/>
 
     </Grid>
 
-    <ProgressBar IsIndeterminate="False" Value="{Binding PasswordStrength}" Maximum="{Binding PasswordStrengthMax}" HorizontalAlignment="Left"
-                   Minimum="0" IsEnabled="true" MinHeight="4" Height="4" Margin="0,10,0,0" Width="370"/>
+    <ProgressBar Name="progressPwStrength" IsIndeterminate="False" Value="0" Minimum="0" Maximum="17" HorizontalAlignment="Left"
+                   IsEnabled="true" MinHeight="4" Height="4" Margin="0,10,0,0" Width="370"/>
 
-    <Panel Margin="0,5,0,0" Width="370" Background="{Binding PasswordRatingColor}">
+    <Panel Margin="0,5,0,0" Width="370" Background="Crimson" Name="pnlPasswordRating">
       <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-        <TextBlock Margin="10,5" FontSize="12" Text="{Binding PasswordStrengthRating}" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
+        <TextBlock Name="lblPasswordStrength" Margin="10,5" FontSize="12" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
       </StackPanel>
     </Panel>
 
@@ -43,15 +44,15 @@
       </Panel.Resources>
       <StackPanel Orientation="Vertical" HorizontalAlignment="Right">
         <StackPanel Orientation="Horizontal">
-          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding UppercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <Ellipse Name="shapeUppercaseIndicator" Stroke="Black" StrokeThickness="1" Fill="Crimson" Width="12" Height="12"></Ellipse>
           <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization UppercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding LowercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <Ellipse Name="shapeLowercaseIndicator" Stroke="Black" StrokeThickness="1" Fill="Crimson" Width="12" Height="12"></Ellipse>
           <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization LowercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
         </StackPanel>
         <StackPanel Orientation="Horizontal">
-          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding DigitsIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <Ellipse Name="shapeDigigsIndicator" Stroke="Black" StrokeThickness="1" Fill="Crimson" Width="12" Height="12"></Ellipse>
           <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization DigitsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding SymbolsIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <Ellipse Name="shapeSymbolsIndicator" Stroke="Black" StrokeThickness="1" Fill="Crimson" Width="12" Height="12"></Ellipse>
           <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization SymbolsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
         </StackPanel>
       </StackPanel>

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
@@ -20,11 +20,11 @@
       </Grid.RowDefinitions>
 
       <TextBlock Margin="0" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" />
-      <loc:CopyPasteTextBox Text="{Binding NewPassword}" Name="txtNewPassword" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
+      <loc:CopyPasteTextBox Name="txtNewPassword" Text="" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
                             PasswordChar="*" Grid.Row="0" Grid.Column="1"/>
 
       <TextBlock Margin="0,10,0,0" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
-      <loc:CopyPasteTextBox Margin="0,10,0,0" Text="{Binding NewPasswordVerify}" Name="txtNewPasswordVerify" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
+      <loc:CopyPasteTextBox Margin="0,10,0,0" Name="txtNewPasswordVerify" Text="" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
                             PasswordChar="*" Grid.Row="1" Grid.Column="1"/>
 
     </Grid>
@@ -32,8 +32,8 @@
     <ProgressBar Name="progressPwStrength" IsIndeterminate="False" Value="0" Minimum="0" Maximum="17" HorizontalAlignment="Left"
                    IsEnabled="true" MinHeight="4" Height="4" Margin="0,10,0,0" Width="370"/>
 
-    <!-- Not sure why the "-7" margin is necessary here, but without it, the panel will be too far to the right  -->
-    <Panel Margin="-7,5,0,0" Width="370" Background="Crimson" Name="pnlPasswordRating">
+    <!-- Not sure why the "-10" margin is necessary here, but without it, the panel will be too far to the right  -->
+    <Panel Margin="-10,0,0,0" Width="370" Background="Crimson" Name="pnlPasswordRating">
       <TextBlock Name="lblPasswordStrength" Margin="10,5" FontSize="12" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
     </Panel>
 

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
@@ -4,7 +4,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
-             Name="NewPasswordWidget"
              x:Class="SQRLDotNetClientUI.Views.NewPasswordWidget">
 
   <StackPanel Orientation="Vertical">

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
@@ -32,10 +32,9 @@
     <ProgressBar Name="progressPwStrength" IsIndeterminate="False" Value="0" Minimum="0" Maximum="17" HorizontalAlignment="Left"
                    IsEnabled="true" MinHeight="4" Height="4" Margin="0,10,0,0" Width="370"/>
 
-    <Panel Margin="0,5,0,0" Width="370" Background="Crimson" Name="pnlPasswordRating">
-      <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-        <TextBlock Name="lblPasswordStrength" Margin="10,5" FontSize="12" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
-      </StackPanel>
+    <!-- Not sure why the "-7" margin is necessary here, but without it, the panel will be too far to the right  -->
+    <Panel Margin="-7,5,0,0" Width="370" Background="Crimson" Name="pnlPasswordRating">
+      <TextBlock Name="lblPasswordStrength" Margin="10,5" FontSize="12" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
     </Panel>
 
     <Panel Margin="0,5,0,0" Width="370">

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml
@@ -1,0 +1,62 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
+             mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="450"
+             x:Class="SQRLDotNetClientUI.Views.NewPasswordWidget">
+
+  <StackPanel Orientation="Vertical">
+
+    <Grid ShowGridLines="False">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="100"/>
+        <ColumnDefinition Width="250"/>
+      </Grid.ColumnDefinitions>
+      <Grid.RowDefinitions>
+        <RowDefinition />
+        <RowDefinition />
+      </Grid.RowDefinitions>
+
+      <TextBlock Margin="0" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="0" Grid.Column="0" />
+      <loc:CopyPasteTextBox Margin="0" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" 
+                            PasswordChar="*" Grid.Row="0" Grid.Column="1"/>
+
+      <TextBlock Margin="0,10,0,0" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="1" Grid.Column="0" />
+      <loc:CopyPasteTextBox Margin="0,10,0,0" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
+                            PasswordChar="*" Grid.Row="1" Grid.Column="1"/>
+
+    </Grid>
+
+    <ProgressBar IsIndeterminate="False" Value="{Binding PasswordStrength}" Maximum="{Binding PasswordStrengthMax}" HorizontalAlignment="Left"
+                   Minimum="0" IsEnabled="true" MinHeight="4" Height="4" Margin="0,10,0,0" Width="370"/>
+
+    <Panel Margin="0,5,0,0" Width="370" Background="{Binding PasswordRatingColor}">
+      <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+        <TextBlock Margin="10,5" FontSize="12" Text="{Binding PasswordStrengthRating}" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
+      </StackPanel>
+    </Panel>
+
+    <Panel Margin="0,5,0,0" Width="370">
+      <Panel.Resources>
+        <loc:StringUppercaseConverter x:Key="stringUppercaseConverter" />
+      </Panel.Resources>
+      <StackPanel Orientation="Vertical" HorizontalAlignment="Right">
+        <StackPanel Orientation="Horizontal">
+          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding UppercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization UppercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
+          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding LowercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization LowercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal">
+          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding DigitsIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization DigitsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
+          <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding SymbolsIndicatorColor}" Width="12" Height="12"></Ellipse>
+          <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization SymbolsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
+        </StackPanel>
+      </StackPanel>
+    </Panel>
+    
+  </StackPanel>
+  
+</UserControl>

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
@@ -1,19 +1,133 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Threading;
+using SQRLDotNetClientUI.AvaloniaExtensions;
+using SQRLDotNetClientUI.Models;
+using System.Reactive.Linq;
+using System;
+using Avalonia.Controls.Shapes;
+using Avalonia.Data;
 
 namespace SQRLDotNetClientUI.Views
 {
     public class NewPasswordWidget : UserControl
     {
+        private static IBrush BRUSH_POOR = new SolidColorBrush(new Color(0xFF, 0xF0, 0x80, 0x80));
+        private static IBrush BRUSH_MEDIUM = new SolidColorBrush(new Color(0xFF, 0xFF, 0xFA, 0xCD));
+        private static IBrush BRUSH_GOOD = new SolidColorBrush(new Color(0xFF, 0x32, 0xCD, 0x32));
+
+        private LocalizationExtension _loc = new LocalizationExtension();
+        private PasswordStrengthMeter _pwdStrengthMeter = new PasswordStrengthMeter();
+        private CopyPasteTextBox _txtNewPassword = null;
+        private CopyPasteTextBox _txtNewPasswordVerify = null;
+        private Panel _pnlPasswordRating = null;
+        private ProgressBar _progressPwStrength = null;
+        private TextBlock _lblPasswordStrength = null;
+        private Ellipse _shapeUppercaseIndicator = null;
+        private Ellipse _shapeLowercaseIndicator = null;
+        private Ellipse _shapeDigigsIndicator = null;
+        private Ellipse _shapeSymbolsIndicator = null;
+
+        public static readonly AvaloniaProperty<bool> PasswordsMatchProperty =
+            AvaloniaProperty.Register<NewPasswordWidget, bool>("PasswordsMatch", defaultValue: false, 
+                defaultBindingMode: BindingMode.TwoWay);
+
+        /// <summary>
+        /// Indicates whether the entered password and the password verification 
+        /// are equal.
+        /// </summary>
+        public bool PasswordsMatch
+        {
+            get { return this.GetValue(PasswordsMatchProperty); }
+            set { this.SetValue(PasswordsMatchProperty, value); }
+        }
+
         public NewPasswordWidget()
         {
             this.InitializeComponent();
+
+            _pwdStrengthMeter.ScoreUpdated += PasswordStrengthScoreUpdated;
+            _txtNewPassword = this.FindControl<CopyPasteTextBox>("txtNewPassword");
+            _txtNewPasswordVerify = this.FindControl<CopyPasteTextBox>("txtNewPasswordVerify");
+            _pnlPasswordRating = this.FindControl<Panel>("pnlPasswordRating");
+            _progressPwStrength = this.FindControl<ProgressBar>("progressPwStrength");
+            _lblPasswordStrength = this.FindControl<TextBlock>("lblPasswordStrength");
+            _shapeUppercaseIndicator = this.FindControl<Ellipse>("shapeUppercaseIndicator");
+            _shapeLowercaseIndicator = this.FindControl<Ellipse>("shapeLowercaseIndicator");
+            _shapeDigigsIndicator = this.FindControl<Ellipse>("shapeDigigsIndicator");
+            _shapeSymbolsIndicator = this.FindControl<Ellipse>("shapeSymbolsIndicator");
+
+            _txtNewPassword.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
+            {
+                _pwdStrengthMeter.Update(value);
+                CheckPasswordVerification();
+            });
+
+            _txtNewPasswordVerify.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
+            {
+                CheckPasswordVerification();
+            });
         }
 
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
+        }
+
+        /// <summary>
+        /// Checks if the password verification matches the new password
+        /// and enables/disables UI controls accordingly.
+        /// </summary>
+        private void CheckPasswordVerification()
+        {
+            if (!string.IsNullOrEmpty(_txtNewPassword.Text) && 
+                _txtNewPassword.Text == _txtNewPasswordVerify.Text)
+            {
+                this.PasswordsMatch = true;
+            }
+            else this.PasswordsMatch = false;
+        }
+
+        /// <summary>
+        /// Gets called if the <c>PasswordStrengthMeter</c> has calculated a new
+        /// password strength rating.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void PasswordStrengthScoreUpdated(object sender, ScoreUpdatedEventArgs e)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                string ratingText = _loc.GetLocalizationValue("PasswordStrength") + ": ";
+
+                switch (e.Score.Rating)
+                {
+                    case PasswordRating.POOR:
+                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingPoor");
+                        _pnlPasswordRating.Background = BRUSH_POOR;
+                        break;
+
+                    case PasswordRating.MEDIUM:
+                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingMedium");
+                        _pnlPasswordRating.Background = BRUSH_MEDIUM;
+                        break;
+
+                    case PasswordRating.GOOD:
+                        ratingText += _loc.GetLocalizationValue("PasswordStrengthRatingGood");
+                        _pnlPasswordRating.Background = BRUSH_GOOD;
+                        break;
+                }
+
+                _shapeUppercaseIndicator.Fill = e.Score.UppercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
+                _shapeLowercaseIndicator.Fill = e.Score.LowercaseUsed ? BRUSH_GOOD : BRUSH_POOR;
+                _shapeDigigsIndicator.Fill = e.Score.DigitsUsed ? BRUSH_GOOD : BRUSH_POOR;
+                _shapeSymbolsIndicator.Fill = e.Score.SymbolsUsed ? BRUSH_GOOD : BRUSH_POOR;
+
+                _lblPasswordStrength.Text = ratingText;
+                _progressPwStrength.Value = (double)e.Score.StrengthPoints;
+            });
         }
     }
 }

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
@@ -38,12 +38,12 @@ namespace SQRLDotNetClientUI.Views
             AvaloniaProperty.Register<NewPasswordWidget, bool>(nameof(PasswordsMatch), defaultValue: false, 
                 defaultBindingMode: BindingMode.TwoWay);
 
-        public static readonly AvaloniaProperty<string> PasswordProperty =
-            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(Password),
+        public static readonly AvaloniaProperty<string> NewPasswordProperty =
+            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(NewPassword),
                 defaultBindingMode: BindingMode.TwoWay);
 
-        public static readonly AvaloniaProperty<string> PasswordVerificationProperty =
-            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(PasswordVerification),
+        public static readonly AvaloniaProperty<string> NewPasswordVerificationProperty =
+            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(NewPasswordVerification),
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -59,19 +59,19 @@ namespace SQRLDotNetClientUI.Views
         /// <summary>
         /// The password entered by the user.
         /// </summary>
-        public string Password
+        public string NewPassword
         {
-            get { return this.GetValue(PasswordProperty); }
-            set { this.SetValue(PasswordProperty, value); }
+            get { return this.GetValue(NewPasswordProperty); }
+            set { this.SetValue(NewPasswordProperty, value); }
         }
 
         /// <summary>
         /// The password verification entered by the user.
         /// </summary>
-        public string PasswordVerification
+        public string NewPasswordVerification
         {
-            get { return this.GetValue(PasswordVerificationProperty); }
-            set { this.SetValue(PasswordVerificationProperty, value); }
+            get { return this.GetValue(NewPasswordVerificationProperty); }
+            set { this.SetValue(NewPasswordVerificationProperty, value); }
         }
 
         public NewPasswordWidget()
@@ -92,13 +92,13 @@ namespace SQRLDotNetClientUI.Views
             _txtNewPassword.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
             {
                 _pwdStrengthMeter.Update(value);
-                this.Password = value;
+                this.NewPassword = value;
                 CheckPasswordVerification();
             });
 
             _txtNewPasswordVerify.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
             {
-                this.PasswordVerification = value;
+                this.NewPasswordVerification = value;
                 CheckPasswordVerification();
             });
         }

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
@@ -12,6 +12,10 @@ using Avalonia.Data;
 
 namespace SQRLDotNetClientUI.Views
 {
+    /// <summary>
+    /// Represents a collection of UI controls for entering and verifying 
+    /// a new password . It also displays a "password strength meter".
+    /// </summary>
     public class NewPasswordWidget : UserControl
     {
         private static IBrush BRUSH_POOR = new SolidColorBrush(new Color(0xFF, 0xF0, 0x80, 0x80));
@@ -31,7 +35,15 @@ namespace SQRLDotNetClientUI.Views
         private Ellipse _shapeSymbolsIndicator = null;
 
         public static readonly AvaloniaProperty<bool> PasswordsMatchProperty =
-            AvaloniaProperty.Register<NewPasswordWidget, bool>("PasswordsMatch", defaultValue: false, 
+            AvaloniaProperty.Register<NewPasswordWidget, bool>(nameof(PasswordsMatch), defaultValue: false, 
+                defaultBindingMode: BindingMode.TwoWay);
+
+        public static readonly AvaloniaProperty<string> PasswordProperty =
+            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(Password),
+                defaultBindingMode: BindingMode.TwoWay);
+
+        public static readonly AvaloniaProperty<string> PasswordVerificationProperty =
+            AvaloniaProperty.Register<NewPasswordWidget, string>(nameof(PasswordVerification),
                 defaultBindingMode: BindingMode.TwoWay);
 
         /// <summary>
@@ -42,6 +54,24 @@ namespace SQRLDotNetClientUI.Views
         {
             get { return this.GetValue(PasswordsMatchProperty); }
             set { this.SetValue(PasswordsMatchProperty, value); }
+        }
+
+        /// <summary>
+        /// The password entered by the user.
+        /// </summary>
+        public string Password
+        {
+            get { return this.GetValue(PasswordProperty); }
+            set { this.SetValue(PasswordProperty, value); }
+        }
+
+        /// <summary>
+        /// The password verification entered by the user.
+        /// </summary>
+        public string PasswordVerification
+        {
+            get { return this.GetValue(PasswordVerificationProperty); }
+            set { this.SetValue(PasswordVerificationProperty, value); }
         }
 
         public NewPasswordWidget()
@@ -62,11 +92,13 @@ namespace SQRLDotNetClientUI.Views
             _txtNewPassword.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
             {
                 _pwdStrengthMeter.Update(value);
+                this.Password = value;
                 CheckPasswordVerification();
             });
 
             _txtNewPasswordVerify.GetObservable(CopyPasteTextBox.TextProperty).Subscribe(value =>
             {
+                this.PasswordVerification = value;
                 CheckPasswordVerification();
             });
         }

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
@@ -74,6 +74,9 @@ namespace SQRLDotNetClientUI.Views
             set { this.SetValue(NewPasswordVerificationProperty, value); }
         }
 
+        /// <summary>
+        /// Creates a new <c>NewPasswordWidget</c> instance and initializes stuff.
+        /// </summary>
         public NewPasswordWidget()
         {
             this.InitializeComponent();
@@ -110,7 +113,7 @@ namespace SQRLDotNetClientUI.Views
 
         /// <summary>
         /// Checks if the password verification matches the new password
-        /// and enables/disables UI controls accordingly.
+        /// and sets the <c>PasswordsMatch</c> property accordingly.
         /// </summary>
         private void CheckPasswordVerification()
         {
@@ -123,11 +126,11 @@ namespace SQRLDotNetClientUI.Views
         }
 
         /// <summary>
-        /// Gets called if the <c>PasswordStrengthMeter</c> has calculated a new
+        /// Gets called when the <c>PasswordStrengthMeter</c> has calculated a new
         /// password strength rating.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
+        /// <param name="sender">The <c>PasswordStrengthMeter</c> object posting the event.</param>
+        /// <param name="e">The parameter containing the updated password rating.</param>
         private void PasswordStrengthScoreUpdated(object sender, ScoreUpdatedEventArgs e)
         {
             Dispatcher.UIThread.Post(() =>

--- a/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
+++ b/SQRLDotNetClientUI/Views/NewPasswordWidget.xaml.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SQRLDotNetClientUI.Views
+{
+    public class NewPasswordWidget : UserControl
+    {
+        public NewPasswordWidget()
+        {
+            this.InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/SQRLDotNetClientUI/Views/ReKeyView.xaml
+++ b/SQRLDotNetClientUI/Views/ReKeyView.xaml
@@ -3,70 +3,39 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLDotNetClientUI.AvaloniaExtensions;assembly=SQRLDotNetClientUI"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:Class="SQRLDotNetClientUI.Views.ReKeyView">
-  <DockPanel>
-    <Grid DockPanel.Dock="Top" Margin="10">
+  
+  <DockPanel Margin="10">
+    
+    <Grid DockPanel.Dock="Top">
       <Grid.ColumnDefinitions>
         <ColumnDefinition Width="100"/>
         <ColumnDefinition Width="275"/>
       </Grid.ColumnDefinitions>
       <Grid.RowDefinitions>
         <RowDefinition />
-        <RowDefinition Height="100" />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        <RowDefinition />
-        
-
+        <RowDefinition Height="130" />
       </Grid.RowDefinitions>
 
       <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right"
              VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
       <TextBlock VerticalAlignment="Center" FontWeight="Bold" Margin="10" Text="{loc:Localization ReKeyIdentityHeading}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
-      <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="1"  Text="{loc:Localization ReKeyIdentityExplanation}" TextWrapping="Wrap" />
 
-      <TextBlock Margin="10" Text="{loc:Localization NewPasswordLabel}" VerticalAlignment="Center" Grid.Row="3" Grid.Column="0" TextWrapping="Wrap" />
-      <loc:CopyPasteTextBox Margin="10" Text="{Binding NewPassword}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top" PasswordChar="*" Grid.Row="3" Grid.Column="1"/>
-
-      <TextBlock Margin="10,0,10,10" Text="{loc:Localization RetypePasswordLabel}" VerticalAlignment="Center" Grid.Row="4" Grid.Column="0" TextWrapping="Wrap" />
-      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding NewPasswordVerify}" Width="250" HorizontalAlignment="Left" VerticalAlignment="Top"
-                            PasswordChar="*" Grid.Row="4" Grid.Column="1"/>
-
-      <ProgressBar IsIndeterminate="False" Value="{Binding PasswordStrength}" Maximum="{Binding PasswordStrengthMax}" HorizontalAlignment="Left"
-                         Minimum="0" IsEnabled="true" MinHeight="4" Height="4" Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="10,10,10,5" Width="370"/>
-      <Panel Margin="10,0,10,5" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Width="370" Background="{Binding PasswordRatingColor}">
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-          <TextBlock Margin="10,5,10,5" FontSize="12" Text="{Binding PasswordStrengthRating}" HorizontalAlignment="Center">Password strength: POOR</TextBlock>
-        </StackPanel>
-      </Panel>
-
-      <Panel Margin="10,0,10,10" Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Width="370">
-        <Panel.Resources>
-          <loc:StringUppercaseConverter x:Key="stringUppercaseConverter" />
-        </Panel.Resources>
-        <StackPanel Orientation="Vertical" HorizontalAlignment="Right">
-          <StackPanel Orientation="Horizontal">
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding UppercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization UppercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding LowercaseIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization LowercaseIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          </StackPanel>
-          <StackPanel Orientation="Horizontal">
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding DigitsIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization DigitsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-            <Ellipse Stroke="Black" StrokeThickness="1" Fill="{Binding SymbolsIndicatorColor}" Width="12" Height="12"></Ellipse>
-            <TextBlock Width="120" Margin="10,5,10,5" FontSize="12" Text="{loc:Localization SymbolsIndicator, Converter={StaticResource stringUppercaseConverter}}" HorizontalAlignment="Center"/>
-          </StackPanel>
-        </StackPanel>
-      </Panel>
-
+      <ScrollViewer Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2">
+        <TextBlock Text="{loc:Localization ReKeyIdentityExplanation}" Width="370" TextWrapping="Wrap" />
+      </ScrollViewer>
+    
     </Grid>
-    <DockPanel DockPanel.Dock="Bottom" Margin="10" >
+
+    <v:NewPasswordWidget DockPanel.Dock="Top" Margin="0,10,0,0" 
+                         NewPassword="{Binding NewPassword}"
+                         NewPasswordVerification="{Binding NewPasswordVerification}"
+                         PasswordsMatch="{Binding PasswordsMatch}" />
+    
+    <DockPanel DockPanel.Dock="Bottom">
     <Button DockPanel.Dock="Left" Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Height="25"  Width="70" VerticalAlignment="Bottom" HorizontalAlignment="Left"  />
     <Button DockPanel.Dock="Right" Content="{loc:Localization BtnNext}" Margin="10" Command="{Binding Next}" Height="25" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="70" IsEnabled="{Binding CanSave}"  />
     </DockPanel>


### PR DESCRIPTION
Closes #69.

### Description:

This turns the "new password / password verify" input fields and the corresponding password strength meter into a self-contained `UserControl`.

The view/view model that uses the control now doesn't have to deal with the password rating stuff in any way, it's all handled by the control.

### Usage:
The control can be used from XAML like this:

First, include the namespace for our views:
```XAML
xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
```

Then, use it just like any other control. The properties `NewPassword`, `NewPasswordVerification` and `PasswordsMatch` can be bound by the user to allow for maximum flexibility:
```XAML
<v:NewPasswordWidget NewPassword="{Binding NewPassword}" 
                     NewPasswordVerification="{Binding NewPasswordVerification}"
                     PasswordsMatch="{Binding PasswordsMatch}" />
```

### Notes:
The new control is already deployed on:
- ChangePasswordView
- ReKeyView
- NewIdentityView
- ImportIdentitySetupView