### PR TITLE
Creates Auto Update Ability

### DIFF
--- a/GitAPIHubHelper/GitAPIHubHelper.csproj
+++ b/GitAPIHubHelper/GitAPIHubHelper.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+  </ItemGroup>
+
+</Project>

--- a/GitAPIHubHelper/GitHubHelper.cs
+++ b/GitAPIHubHelper/GitHubHelper.cs
@@ -23,7 +23,7 @@ namespace GitAPIHubHelper
             }
             catch(Exception ex)
             {
-                Console.WriteLine("Error Downloading Releases");
+                Console.WriteLine($"Error Downloading Releases. Error: {ex}");
             }
             return (Newtonsoft.Json.JsonConvert.DeserializeObject<List<GithubRelease>>(jsonData)).ToArray();
         }
@@ -43,7 +43,7 @@ namespace GitAPIHubHelper
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Error Downloading: {url}");
+                Console.WriteLine($"Error Downloading: {url} Error: {ex}");
                 success = false;
             }
             return success;

--- a/GitAPIHubHelper/GitHubHelper.cs
+++ b/GitAPIHubHelper/GitHubHelper.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Reflection;
+
+namespace GitAPIHubHelper
+{
+    public static class GitHubHelper
+    {
+        public static GithubRelease[] GetReleases()
+        {
+            string jsonData = "";
+            var wc =new WebClient
+            {
+                CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore)
+            };
+
+            wc.Headers.Add("User-Agent", "SQRL-Intaller");
+            try
+            {
+                jsonData = wc.DownloadString("https://api.github.com/repos/sqrldev/SQRLDotNetClient/releases");
+            }
+            catch(Exception ex)
+            {
+                Console.WriteLine("Error Downloading Releases");
+            }
+            return (Newtonsoft.Json.JsonConvert.DeserializeObject<List<GithubRelease>>(jsonData)).ToArray();
+        }
+
+        public static bool DownloadFile(string url, string target)
+        {
+            bool success = true;
+            var wc = new WebClient
+            {
+                CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore)
+            };
+
+            wc.Headers.Add("User-Agent", "SQRL-Intaller");
+            try
+            {
+                wc.DownloadFile(url,target);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error Downloading: {url}");
+                success = false;
+            }
+            return success;
+        }
+
+        public static bool CheckForUpdates()
+        {
+            bool updateAvailable = false;
+            var directory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (File.Exists(Path.Combine(directory, "sqrlversion.json")))
+            {
+                string tag = Newtonsoft.Json.JsonConvert.DeserializeObject<string>(File.ReadAllText(Path.Combine(directory, "sqrlversion.json")));
+                var releases = GitAPIHubHelper.GitHubHelper.GetReleases();
+                if (releases != null && !tag.Equals(releases[0].tag_name, StringComparison.OrdinalIgnoreCase))
+                {
+                    updateAvailable = true;
+                }
+                else
+                    updateAvailable = false;
+            }
+            else
+                updateAvailable = false;
+
+            return updateAvailable;
+        }
+    }
+}

--- a/GitAPIHubHelper/GithubReleases.cs
+++ b/GitAPIHubHelper/GithubReleases.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace GitAPIHubHelper
+namespace GitHubApi
 {
 
     public class GithubRelease

--- a/GitAPIHubHelper/GithubReleases.cs
+++ b/GitAPIHubHelper/GithubReleases.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace SQRLPlatformAwareInstaller.Models
+namespace GitAPIHubHelper
 {
 
     public class GithubRelease

--- a/SQRLDotNetClient.sln
+++ b/SQRLDotNetClient.sln
@@ -15,7 +15,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SQRLDotNetClientUI", "SQRLD
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SQRLIPCTestClient", "SQRLIPCTestClient\SQRLIPCTestClient.csproj", "{C8A66E27-ED37-49A9-9465-8EF761FD51AD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SQRLPlatformAwareInstaller", "SQRLPlatformAwareInstaller\SQRLPlatformAwareInstaller.csproj", "{6FC399D8-72A5-4517-8DE6-1B4D8B335997}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SQRLPlatformAwareInstaller", "SQRLPlatformAwareInstaller\SQRLPlatformAwareInstaller.csproj", "{6FC399D8-72A5-4517-8DE6-1B4D8B335997}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GitAPIHubHelper", "GitAPIHubHelper\GitAPIHubHelper.csproj", "{9AC34E1E-B531-4179-8832-B4E113E312D9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -51,6 +53,10 @@ Global
 		{6FC399D8-72A5-4517-8DE6-1B4D8B335997}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6FC399D8-72A5-4517-8DE6-1B4D8B335997}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6FC399D8-72A5-4517-8DE6-1B4D8B335997}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9AC34E1E-B531-4179-8832-B4E113E312D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9AC34E1E-B531-4179-8832-B4E113E312D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9AC34E1E-B531-4179-8832-B4E113E312D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9AC34E1E-B531-4179-8832-B4E113E312D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -50,6 +50,8 @@
     { "IdentitySettingsMenuItemHeader": "Identity _Settings" },
     { "HelpMenuItemHeader": "_Help" },
     { "AboutMenuItemHeader": "_About" },
+    { "NewUpdateAvailable": "New Version Available!" },
+    { "NewUpdateAvailableRunApp": "New SQRL version Available, run main application to update" },
     { "LoadedIdentityLabel": "Loaded Identity:" },
     { "BtnNewIdentity": "New Identity" },
     { "BtnNewIdentity": "New Identity" },
@@ -133,7 +135,9 @@
     { "SecretDialogError": "Please use the OK button to exit this dialog." },
     { "OptionsMenuHeader": "_Options" },
     { "LanguageMenuHeader": "_Language" },
-    { "DefaultLanguageMenuItemHeader": "_Default" }
+    { "DefaultLanguageMenuItemHeader": "_Default" },
+    { "MissingInstaller": "The installer file is missing so we can't auto update, would you like to go to the downloads page to get the latest installer?'" }
+
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -186,6 +190,8 @@
     { "IdentitySettingsMenuItemHeader": "Identity _Settings" },
     { "HelpMenuItemHeader": "_Help" },
     { "AboutMenuItemHeader": "_About" },
+    { "NewUpdateAvailable": "New Version Available!" },
+    { "NewUpdateAvailableRunApp": "New SQRL version Available, run main application to update" },
     { "LoadedIdentityLabel": "Loaded Identity:" },
     { "BtnNewIdentity": "New Identity" },
     { "BtnImportIdentity": "Import Identity" },
@@ -268,7 +274,8 @@
     { "SecretDialogError": "Please use the OK button to exit this dialog." },
     { "OptionsMenuHeader": "_Options" },
     { "LanguageMenuHeader": "_Language" },
-    { "DefaultLanguageMenuItemHeader": "_Default" }
+    { "DefaultLanguageMenuItemHeader": "_Default" },
+    { "MissingInstaller": "The installer file is missing so we can't auto update, would you like to go to the downloads page to get the latest installer?'" }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -321,6 +328,8 @@
     { "IdentitySettingsMenuItemHeader": "Identitäts-Ein_stellungen" },
     { "HelpMenuItemHeader": "_Hilfe" },
     { "AboutMenuItemHeader": "Ü_ber" },
+    { "NewUpdateAvailable": "Neue Aktualisierung Verfügbar" },
+    { "NewUpdateAvailableRunApp": "Neue SQRL-Version verfügbar. Führen Sie die Hauptanwendung aus, um ein Upgrade durchzuführen" },
     { "LoadedIdentityLabel": "Aktuelle Identität:" },
     { "BtnNewIdentity": "Neue Identität" },
     { "BtnImportIdentity": "Identität importieren" },
@@ -403,6 +412,7 @@
     { "SecretDialogError": "Bitte benützen Sie den OK-Button, um diesen Dialog zu schließen." },
     { "OptionsMenuHeader": "_Optionen" },
     { "LanguageMenuHeader": "_Sprache" },
-    { "DefaultLanguageMenuItemHeader": "_Standard" }
+    { "DefaultLanguageMenuItemHeader": "_Standard" },
+    { "MissingInstaller": "The installer file is missing so we can't auto update, would you like to go to the downloads page to get the latest installer?'" }
   ]
 }

--- a/SQRLDotNetClientUI/Properties/launchSettings.json
+++ b/SQRLDotNetClientUI/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "SQRLDotNetClientUI": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "https://grc.com/asdasd"
     }
   }
 }

--- a/SQRLDotNetClientUI/Properties/launchSettings.json
+++ b/SQRLDotNetClientUI/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "SQRLDotNetClientUI": {
-      "commandName": "Project",
-      "commandLineArgs": "https://grc.com/asdasd"
+      "commandName": "Project"
     }
   }
 }

--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -222,6 +222,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\GitAPIHubHelper\GitAPIHubHelper.csproj" />
     <ProjectReference Include="..\SQRLUtilsLib\SQRLUtilsLib.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -23,6 +23,14 @@ namespace SQRLDotNetClientUI.ViewModels
             Remove
         };
 
+        private bool _NewUpdateAvailable=false;
+        public bool NewUpdateAvailable
+        {
+            get => _NewUpdateAvailable;
+            set { this.RaiseAndSetIfChanged(ref _NewUpdateAvailable, value); }
+        }
+
+
         private LoginAction action = LoginAction.Login;
         public LoginAction Action
         {
@@ -141,6 +149,14 @@ namespace SQRLDotNetClientUI.ViewModels
             });
 
             CheckForQuickPass();
+
+            CheckForUpdate();
+
+        }
+
+        private void CheckForUpdate()
+        {
+            this.NewUpdateAvailable = this.NewUpdateAvailable = GitAPIHubHelper.GitHubHelper.CheckForUpdates();
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -154,9 +154,9 @@ namespace SQRLDotNetClientUI.ViewModels
 
         }
 
-        private void CheckForUpdate()
+        private async void CheckForUpdate()
         {
-            this.NewUpdateAvailable = this.NewUpdateAvailable = GitAPIHubHelper.GitHubHelper.CheckForUpdates();
+            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates();
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -233,10 +233,10 @@ namespace SQRLDotNetClientUI.ViewModels
         /// <summary>
         /// Checks for new version in github and enables the Alert Button
         /// </summary>
-        public void CheckForUpdates()
+        public async void CheckForUpdates()
         {
 
-            this.NewUpdateAvailable = GitAPIHubHelper.GitHubHelper.CheckForUpdates();
+            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates();
         }
 
 

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -250,8 +250,18 @@ namespace SQRLDotNetClientUI.ViewModels
             if(File.Exists(Path.Combine(directory,installer)))
             {
                 var tempFile = Path.GetTempPath();
-                File.Copy(installer, Path.Combine(tempFile, Path.GetFileName(installer)), true);
-                Process.Start(Path.Combine(tempFile, Path.GetFileName(installer)));
+                File.Copy(Path.Combine(directory, installer), Path.Combine(tempFile, Path.GetFileName(installer)), true);
+                if(RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    Process proc = new Process();
+                    proc.StartInfo.FileName = Path.Combine(tempFile, Path.GetFileName(installer));
+                    proc.StartInfo.UseShellExecute = true;
+                    proc.StartInfo.Verb = "runas";
+                    proc.Start();
+                }
+                else
+                    Process.Start(Path.Combine(tempFile, Path.GetFileName(installer)));
+
                 this._mainWindow.Exit();
             }
             else

--- a/SQRLDotNetClientUI/Views/AuthenticationView.xaml
+++ b/SQRLDotNetClientUI/Views/AuthenticationView.xaml
@@ -14,8 +14,10 @@
   <DockPanel Margin="0">
 
     <!-- Header image -->
-    <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Margin="20" Height="50" DockPanel.Dock="Top" HorizontalAlignment="Center"></Image>
-
+    
+    <TextBlock IsVisible="{Binding NewUpdateAvailable}" HorizontalAlignment="Center" Foreground="Red" FontWeight="Bold"  Margin="10" Text="{loc:Localization NewUpdateAvailableRunApp}" TextWrapping="Wrap" Width="370" DockPanel.Dock="Top" />
+    <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Margin="10" Height="50" DockPanel.Dock="Top" HorizontalAlignment="Center"></Image>
+    
     <!-- Login message and site id -->
       <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Margin="10, 0, 10, 5" Text="{loc:Localization AuthMessage}" FontSize="13" TextWrapping="Wrap" />
       <TextBlock HorizontalAlignment="Center" DockPanel.Dock="Top" Margin="10, 0, 10, 0" Text="www.grc.com" FontSize="22" FontFamily="Consolas" Foreground="#007cc3" TextWrapping="Wrap"/>
@@ -90,6 +92,7 @@
     <!-- Progress indicator -->
     <ProgressBar  DockPanel.Dock="Bottom" Margin="10" IsIndeterminate="False" Value="{Binding Block1Progress}" Maximum="{Binding MaxProgress}"
                  Minimum="0" IsEnabled="true"  Height="20"  MinWidth="10"/>
+    
 
   </DockPanel>
 

--- a/SQRLDotNetClientUI/Views/MainMenuView.xaml
+++ b/SQRLDotNetClientUI/Views/MainMenuView.xaml
@@ -33,6 +33,7 @@
         <MenuItem Header="{loc:Localization LanguageMenuHeader}" Name="menuLanguage"/>
       </MenuItem>
       <MenuItem Header="{loc:Localization HelpMenuItemHeader}" >
+        <MenuItem Header="{loc:Localization CheckForUpdates}" Command="{Binding CheckForUpdates}" />
         <MenuItem Header="{loc:Localization AboutMenuItemHeader}" />
       </MenuItem>
     </Menu>
@@ -90,7 +91,8 @@
       <Button Content="{loc:Localization BtnExportIdentity}" Name="btnExport" Command="{Binding ExportIdentity}" Height="30" Width="130" Margin="10" Grid.Row="2" Grid.Column="1" IsEnabled="{Binding CurrentIdentityLoaded}" HorizontalAlignment="Left"/>
       <Button Content="{loc:Localization BtnDeleteIdentity}" Name="btnDeleteIdentity" Command="{Binding DeleteIdentity}" Height="30" Width="130" Margin="10" Grid.Row="3" Grid.Column="1" IsEnabled="{Binding CurrentIdentityLoaded}" HorizontalAlignment="Left"/>
       <Button Content="{loc:Localization BtnIdentitySettings}" Name="btnIdentitySettings" Command="{Binding IdentitySettings}" Height="30" Width="130" Margin="10" Grid.Row="3" Grid.Column="0" IsEnabled="{Binding CurrentIdentityLoaded}" />
-      
+
+      <Button Content="{loc:Localization NewUpdateAvailable}" Foreground="Red" FontWeight="Bold" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Margin="10" Width="200" HorizontalAlignment="Center" Command="{Binding InstallUpdate}"  IsVisible="{Binding NewUpdateAvailable}" />
       <!-- Login form (hidden) -->
       <StackPanel Margin="20,15,20,10" Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" IsVisible="False">
       <TextBlock FontSize="15" FontWeight="Bold" HorizontalAlignment="Left" Margin="10,0,0,0" VerticalAlignment="Center">Site URL</TextBlock>

--- a/SQRLDotNetClientUI/Views/MainMenuView.xaml
+++ b/SQRLDotNetClientUI/Views/MainMenuView.xaml
@@ -33,7 +33,7 @@
         <MenuItem Header="{loc:Localization LanguageMenuHeader}" Name="menuLanguage"/>
       </MenuItem>
       <MenuItem Header="{loc:Localization HelpMenuItemHeader}" >
-        <MenuItem Header="{loc:Localization CheckForUpdates}" Command="{Binding CheckForUpdates}" />
+        <MenuItem Header="{loc:Localization CheckForUpdates}" IsEnabled="True" Command="{Binding CheckForUpdates}" />
         <MenuItem Header="{loc:Localization AboutMenuItemHeader}" />
       </MenuItem>
     </Menu>

--- a/SQRLDotNetClientUI/Views/MainMenuView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/MainMenuView.xaml.cs
@@ -26,7 +26,8 @@ namespace SQRLDotNetClientUI.Views
             MenuItem languageMenu = this.FindControl<MenuItem>("menuLanguage");
 
             List<MenuItem> items = new List<MenuItem>();
-            foreach (var lang in new MainMenuViewModel().LanguageMenuItems)
+            var newMenuView = new MainMenuViewModel();
+            foreach (var lang in newMenuView.LanguageMenuItems)
             {
                 MenuItem item = new MenuItem()
                 {
@@ -40,6 +41,9 @@ namespace SQRLDotNetClientUI.Views
             }
 
             languageMenu.Items = items;
+
+            //Derreference for GC
+            newMenuView = null;
         }
 
         private void InitializeComponent()

--- a/SQRLDotNetClientUI/Views/MainWindow.xaml.cs
+++ b/SQRLDotNetClientUI/Views/MainWindow.xaml.cs
@@ -140,7 +140,7 @@ namespace SQRLDotNetClientUI.Views
         /// <summary>
         /// Exits the app by closing the main window.
         /// </summary>
-        private void Exit()
+        public void Exit()
         {
             _reallyClose = true;
             this.Close();

--- a/SQRLPlatformAwareInstaller/App.xaml.cs
+++ b/SQRLPlatformAwareInstaller/App.xaml.cs
@@ -13,9 +13,7 @@ namespace SQRLPlatformAwareInstaller
        
         public override void Initialize()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                if (!Utils.IsAdmin())
-                    throw new System.Exception("This app must be run as an Administrator in Windows or Sudo/Root in Linux");
+
                 AvaloniaXamlLoader.Load(this);
         }
 

--- a/SQRLPlatformAwareInstaller/App.xaml.cs
+++ b/SQRLPlatformAwareInstaller/App.xaml.cs
@@ -13,7 +13,7 @@ namespace SQRLPlatformAwareInstaller
        
         public override void Initialize()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 if (!Utils.IsAdmin())
                     throw new System.Exception("This app must be run as an Administrator in Windows or Sudo/Root in Linux");
                 AvaloniaXamlLoader.Load(this);

--- a/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
+++ b/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
@@ -137,4 +137,7 @@
   <ItemGroup>
     <Resource Include="Assets\sqrl_icon_normal_256.ico" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GitAPIHubHelper\GitAPIHubHelper.csproj" />
+  </ItemGroup>
 </Project>

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -54,7 +54,7 @@ namespace SQRLPlatformAwareInstaller.ViewModels
         private void InitObj(string platform ="WINDOWS")
         {
             //Handle certificate trust Issue from Issue #80
-            ServicePointManager.ServerCertificateValidationCallback = (a, b, c, d) => true;
+            //ServicePointManager.ServerCertificateValidationCallback = (a, b, c, d) => true;
             this.Title = "SQRL Client Installer - Version Selector";
             this.platform = platform;
             wc = new WebClient

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -18,7 +18,7 @@ using ICSharpCode.SharpZipLib.Core;
 using ICSharpCode.SharpZipLib.Zip;
 using System.Security.AccessControl;
 using System.Security.Principal;
-using GitAPIHubHelper;
+using GitHubApi;
 
 namespace SQRLPlatformAwareInstaller.ViewModels 
 {
@@ -51,7 +51,7 @@ namespace SQRLPlatformAwareInstaller.ViewModels
             InitObj();
         }
 
-        private void InitObj(string platform ="WINDOWS")
+        private  void InitObj(string platform ="WINDOWS")
         {
             //Handle certificate trust Issue from Issue #80
             //ServicePointManager.ServerCertificateValidationCallback = (a, b, c, d) => true;
@@ -62,9 +62,9 @@ namespace SQRLPlatformAwareInstaller.ViewModels
                 CachePolicy = new System.Net.Cache.RequestCachePolicy(System.Net.Cache.RequestCacheLevel.NoCacheNoStore)
             };
 
-            wc.Headers.Add("User-Agent", "SQRL-Intaller");
+            wc.Headers.Add("User-Agent", GitHubHelper.UserAgent);
 
-            this.Releases = GitHubHelper.GetReleases();
+            this.Releases =  GitHubHelper.GetReleases().Result;
             this.SelectedRelease = this.Releases.OrderByDescending(r => r.published_at).FirstOrDefault();
             
             PathByPlatForm(this.platform);

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -413,7 +413,7 @@ namespace SQRLPlatformAwareInstaller.ViewModels
 
                     // Manipulate the output filename here as desired.
                     var fullZipToPath = Path.Combine(outFolder, entryFileName);
-                    if(entryFileName.Equals("sqrl.db", StringComparison.OrdinalIgnoreCase) && File.Exists(entryFileName) )
+                    if(entryFileName.Equals("sqrl.db", StringComparison.OrdinalIgnoreCase) && File.Exists(fullZipToPath) )
                     {
                         continue;
                     }

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -233,51 +233,50 @@ namespace SQRLPlatformAwareInstaller.ViewModels
             _shell.Term($"chmod a+x {Executable}",Output.Internal);
         }
 
-        private async void InstallinLinux(string downloadedFileName)
+        private void InstallinLinux(string downloadedFileName)
         {
-            
-            this.InstallStatus ="Installing...";
+
+            this.InstallStatus = "Installing...";
             Executable = Path.Combine(this.InstallationPath, "SQRLDotNetClientUI");
-            await Task.Run(() =>
+
+            if (!Directory.Exists(this.InstallationPath))
             {
-                if (!Directory.Exists(this.InstallationPath))
-                {
-                    Directory.CreateDirectory(this.InstallationPath);
-                }
-                this.DownloadPercentage = 20;
-                //File.Move(downloadedFileName, Executable, true);
-                ExtractZipFile(downloadedFileName, string.Empty, this.InstallationPath);
-                
-                File.Copy(Process.GetCurrentProcess().MainModule.FileName, Path.Combine(this.InstallationPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName)), true);
-                using (StreamWriter sw = new StreamWriter(Path.Combine(this.InstallationPath, "sqrlversion.json")))
-                {
-                    sw.Write(Newtonsoft.Json.JsonConvert.SerializeObject(this.SelectedRelease.tag_name));
-                    sw.Close();
-                }
-                this.DownloadPercentage += 20;
-            });
+                Directory.CreateDirectory(this.InstallationPath);
+            }
+            this.DownloadPercentage = 20;
+            //File.Move(downloadedFileName, Executable, true);
+            ExtractZipFile(downloadedFileName, string.Empty, this.InstallationPath);
+
+            File.Copy(Process.GetCurrentProcess().MainModule.FileName, Path.Combine(this.InstallationPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName)), true);
+            using (StreamWriter sw = new StreamWriter(Path.Combine(this.InstallationPath, "sqrlversion.json")))
+            {
+                sw.Write(Newtonsoft.Json.JsonConvert.SerializeObject(this.SelectedRelease.tag_name));
+                sw.Close();
+            }
+            this.DownloadPercentage += 20;
+
 
             _bridgeSystem = BridgeSystem.Bash;
             _shell = new ShellConfigurator(_bridgeSystem);
 
-            GitHubHelper.DownloadFile(@"https://github.com/sqrldev/SQRLDotNetClient/raw/master/SQRLDotNetClientUI/Assets/SQRL_icon_normal_64.png",Path.Combine(this.InstallationPath,"SQRL.png"));
+            GitHubHelper.DownloadFile(@"https://github.com/sqrldev/SQRLDotNetClient/raw/master/SQRLDotNetClientUI/Assets/SQRL_icon_normal_64.png", Path.Combine(this.InstallationPath, "SQRL.png"));
             StringBuilder sb = new StringBuilder();
             sb.AppendLine($"[Desktop Entry]");
             sb.AppendLine("Name=SQRL");
             sb.AppendLine("Type=Application");
-            sb.AppendLine($"Icon={(Path.Combine(this.InstallationPath,"SQRL.png"))}");
+            sb.AppendLine($"Icon={(Path.Combine(this.InstallationPath, "SQRL.png"))}");
             sb.AppendLine($"Exec={Executable} %u");
             sb.AppendLine("Categories=Internet");
             sb.AppendLine("Terminal=false");
             sb.AppendLine("MimeType=x-scheme-handler/sqrl");
-            File.WriteAllText(Path.Combine(this.InstallationPath,"sqrldev-sqrl.desktop"), sb.ToString());
+            File.WriteAllText(Path.Combine(this.InstallationPath, "sqrldev-sqrl.desktop"), sb.ToString());
             _shell.Term($"chmod -R 777 {this.InstallationPath}", Output.Internal);
-            _shell.Term($"chmod a+x {Executable}",Output.Internal);
-            _shell.Term($"chmod +x {Path.Combine(this.InstallationPath,"sqrldev-sqrl.desktop")}",Output.Internal);
-            _shell.Term($"xdg-desktop-menu install {Path.Combine(this.InstallationPath,"sqrldev-sqrl.desktop")}",Output.Internal);
-            _shell.Term($"gio mime x-scheme-handler/sqrl sqrldev-sqrl.desktop",Output.Internal);
-            _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl",Output.Internal);
-            _shell.Term($"update-desktop-database ~/.local/share/applications/",Output.Internal);
+            _shell.Term($"chmod a+x {Executable}", Output.Internal);
+            _shell.Term($"chmod +x {Path.Combine(this.InstallationPath, "sqrldev-sqrl.desktop")}", Output.Internal);
+            _shell.Term($"xdg-desktop-menu install {Path.Combine(this.InstallationPath, "sqrldev-sqrl.desktop")}", Output.Internal);
+            _shell.Term($"gio mime x-scheme-handler/sqrl sqrldev-sqrl.desktop", Output.Internal);
+            _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl", Output.Internal);
+            _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
 
         }
 

--- a/SQRLPlatformAwareInstaller/Views/MainInstalView.xaml
+++ b/SQRLPlatformAwareInstaller/Views/MainInstalView.xaml
@@ -27,7 +27,7 @@
     <TextBlock Grid.Column="0" Margin="10" FontWeight="Bold" Grid.Row="2" Text="{loc:Localization DetectedPlatform}"/>
     <Image Grid.Row="2" Grid.Column="1" Source="{Binding PlatformImg}" Stretch="None" HorizontalAlignment="Left" ToolTip.Tip="{Binding Platform}" />
     <Button VerticalAlignment="Bottom" Grid.Row="3" Grid.Column="1" Width="100" HorizontalAlignment="Right" Margin="10" Command="{Binding Next}">Next</Button>
-    <Button VerticalAlignment="Bottom" Grid.Row="3" Grid.Column="0" Width="100" HorizontalAlignment="Left" Margin="10">Cancel</Button>
+    <Button VerticalAlignment="Bottom" Grid.Row="3" Grid.Column="0" Width="100" HorizontalAlignment="Left" Margin="10" Command="{Binding Cancel}">Cancel</Button>
   </Grid>
 
 </UserControl>

--- a/SQRLPlatformAwareInstaller/Views/MainWindow.xaml.cs
+++ b/SQRLPlatformAwareInstaller/Views/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ namespace SQRLPlatformAwareInstaller.Views
                 AvaloniaLocator.CurrentMutable.Bind<MainWindow>().ToConstant(this);
             }
             this.LocalizationService = new LocalizationExtension();
+            this.WindowStartupLocation = WindowStartupLocation.CenterScreen;
 #if DEBUG
             this.AttachDevTools();
 #endif


### PR DESCRIPTION
This PR Creates the "Auto Update" functionality for the SQRL client.
It relies on the installer copying itself to the SQRL location, the installer also deposits a sqrlversion.json file in the install location.

On Launch, On Auth Request and On Menu Click the GitHub releases are checked and the latest is compared against the version stored in sqrlversion.json
If they don't match a button is enabled in the main application (as shown below)
![UpdateMain](https://user-images.githubusercontent.com/420837/78280439-182b9c00-74e7-11ea-9e21-22fe6f0056aa.gif)

This button when clicked executes the installer and closes SQRL (all the way out) to allow you to properly upgrade

On Auth Request the user is notified of an available Update though they need to run the main client to upgrade (shown)
![UpdateAuth](https://user-images.githubusercontent.com/420837/78280563-4c9f5800-74e7-11ea-81bd-b14a200098a0.gif)
 
