### PR TITLE
Fix textual export

### DIFF
--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -6,6 +6,7 @@ using ReactiveUI;
 using SQRLDotNetClientUI.Views;
 using SQRLUtilsLib;
 using System;
+using System.Linq;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
@@ -55,7 +56,10 @@ namespace SQRLDotNetClientUI.ViewModels
 
         public async void CopyToClipboard()
         {
-            string identity = SQRL.GenerateTextualIdentityBase56(this.Identity.Block2.ToByteArray());
+            var textualIdentityBytes = this.Identity.Block2.ToByteArray();
+            if (this.Identity.HasBlock(3)) textualIdentityBytes = textualIdentityBytes.Concat(this.Identity.Block3.ToByteArray()).ToArray();
+
+            string identity = SQRL.GenerateTextualIdentityBase56(textualIdentityBytes);
             await Application.Current.Clipboard.SetTextAsync(identity);
             
             await new Views.MessageBox(_loc.GetLocalizationValue("IdentityExportedMessageBoxTitle"),

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -1,10 +1,8 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Platform;
-
 using QRCoder;
 using ReactiveUI;
-using SQRLDotNetClientUI.Models;
 using SQRLDotNetClientUI.Views;
 using SQRLUtilsLib;
 using System;
@@ -49,26 +47,21 @@ namespace SQRLDotNetClientUI.ViewModels
                 this.Identity.WriteToFile(file);
                 
                 await new Views.MessageBox(_loc.GetLocalizationValue("IdentityExportedMessageBoxTitle"),
-                                            string.Format(_loc.GetLocalizationValue("IdentityExportedMessageBoxText"), file),
-                                            MessageBoxSize.Small, MessageBoxButtons.OK,MessageBoxIcons.OK)
-                                            .ShowDialog<MessagBoxDialogResult>(_mainWindow);
-            }
-            else
-            {
-                
+                    string.Format(_loc.GetLocalizationValue("IdentityExportedMessageBoxText"), file),
+                    MessageBoxSize.Small, MessageBoxButtons.OK,MessageBoxIcons.OK)
+                    .ShowDialog<MessagBoxDialogResult>(_mainWindow);
             }
         }
 
         public async void CopyToClipboard()
         {
-            string identity = SQRL.GenerateTextualIdentityBase56(this.Identity.ToByteArray());
+            string identity = SQRL.GenerateTextualIdentityBase56(this.Identity.Block2.ToByteArray());
             await Application.Current.Clipboard.SetTextAsync(identity);
-
             
             await new Views.MessageBox(_loc.GetLocalizationValue("IdentityExportedMessageBoxTitle"),
-                                       _loc.GetLocalizationValue("IdentityCopiedToClipboardMessageBoxText"),
-                                       MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.OK)
-                                       .ShowDialog<MessagBoxDialogResult>(_mainWindow);
+                _loc.GetLocalizationValue("IdentityCopiedToClipboardMessageBoxText"),
+                MessageBoxSize.Medium, MessageBoxButtons.OK, MessageBoxIcons.OK)
+                .ShowDialog<MessagBoxDialogResult>(_mainWindow);
         }
 
         public void Back()


### PR DESCRIPTION
Fixes #92.

### Description:

Only use block type 2 for textual identity export ("Copy to clipboard"). 