### PR TITLE
Fix progress window indicator

### DIFF
--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -64,7 +64,7 @@
     <AvaloniaResource Remove="Views\NewIdentityVerifyView.xaml" />
     <AvaloniaResource Remove="Views\NewIdentityView.xaml" />
     <AvaloniaResource Remove="Views\NewPasswordWidget.xaml" />
-    <AvaloniaResource Remove="Views\ProgressDialog.xaml" />
+    <AvaloniaResource Remove="Views\ProgressDialogView.xaml" />
     <AvaloniaResource Remove="Views\ReKeyView.xaml" />
     <AvaloniaResource Remove="Views\SelectIdentityDialogView.xaml" />
   </ItemGroup>
@@ -104,7 +104,7 @@
     <None Remove="Views\NewIdentityVerifyView.xaml" />
     <None Remove="Views\NewIdentityView.xaml" />
     <None Remove="Views\NewPasswordWidget.xaml" />
-    <None Remove="Views\ProgressDialog.xaml" />
+    <None Remove="Views\ProgressDialogView.xaml" />
     <None Remove="Views\ReKeyView.xaml" />
     <None Remove="Views\SelectIdentityDialogView.xaml" />
   </ItemGroup>
@@ -231,6 +231,9 @@
     <Compile Update="Views\NewPasswordWidget.xaml.cs">
       <DependentUpon>NewPasswordWidget.xaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\ProgressDialogView.xaml.cs">
+      <DependentUpon>ProgressDialogView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />
@@ -251,7 +254,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Views\ProgressDialog.xaml">
+    <EmbeddedResource Include="Views\ProgressDialogView.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
@@ -101,7 +101,7 @@ namespace SQRLDotNetClientUI.ViewModels
 
             var progress = new Progress<KeyValuePair<int, string>>();
             
-            var progressDialog = new ProgressDialogViewModel(progress,this);
+            var progressDialog = new ProgressDialogViewModel(progress,this,false);
             progressDialog.ShowDialog();
 
             var block1Keys = await SQRL.DecryptBlock1(_identityManager.CurrentIdentity, 

--- a/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ChangePasswordViewModel.cs
@@ -100,17 +100,17 @@ namespace SQRLDotNetClientUI.ViewModels
             CanSave = false;
 
             var progress = new Progress<KeyValuePair<int, string>>();
-            var progressDialog = new ProgressDialog(progress);
-            progressDialog.HideFinishedItems = false;
-            _= progressDialog.ShowDialog(_mainWindow);
+            
+            var progressDialog = new ProgressDialogViewModel(progress,this);
+            progressDialog.ShowDialog();
 
             var block1Keys = await SQRL.DecryptBlock1(_identityManager.CurrentIdentity, 
                 this.Password, progress);
 
             if (!block1Keys.DecryptionSucceeded)
             {
+                
                 progressDialog.Close();
-
                 Log.Information("Bad password was supplied for identity id {IdentityUniqueId}",
                 _identityManager.CurrentIdentityUniqueId);
 
@@ -127,6 +127,7 @@ namespace SQRLDotNetClientUI.ViewModels
             var currentId = _identityManager.CurrentIdentity;
             var idCopy = _identityManager.CurrentIdentity.Clone();
             await SQRL.GenerateIdentityBlock1(block1Keys.Imk, block1Keys.Ilk, this.NewPassword, currentId, progress, (int)currentId.Block1.PwdVerifySeconds);
+            
             progressDialog.Close();
 
             // Write the changes back to the db

--- a/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/IdentitySettingsViewModel.cs
@@ -60,12 +60,14 @@ namespace SQRLDotNetClientUI.ViewModels
             }
 
             var progress = new Progress<KeyValuePair<int, string>>();
-            var progressDialog = new ProgressDialog(progress);
-            _ = progressDialog.ShowDialog(_mainWindow);
+            var progressDialog = new ProgressDialogViewModel(progress,this);
+            progressDialog.ShowDialog();
+            
             var block1Keys = await SQRL.DecryptBlock1(Identity, password, progress);
 
             if (!block1Keys.DecryptionSucceeded)
             {
+                
                 progressDialog.Close();
 
                 await new Views.MessageBox(_loc.GetLocalizationValue("ErrorTitleGeneric"),
@@ -80,6 +82,7 @@ namespace SQRLDotNetClientUI.ViewModels
             SQRLIdentity id = await SQRL.GenerateIdentityBlock1(block1Keys.Imk, block1Keys.Ilk, 
                 password, IdentityCopy, progress, IdentityCopy.Block1.PwdVerifySeconds);
 
+            
             progressDialog.Close();
 
             // Swap out the old type 1 block with the updated one

--- a/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ImportIdentitySetupViewModel.cs
@@ -130,9 +130,10 @@ namespace SQRLDotNetClientUI.ViewModels
             var progressBlock2 = new Progress<KeyValuePair<int, string>>();
             var progressDecryptBlock2 = new Progress<KeyValuePair<int, string>>();
 
-            var progressDialog = new ProgressDialog(new List<Progress<KeyValuePair<int, string>>>() { 
-                progressBlock1, progressBlock2, progressDecryptBlock2 });
-            _ = progressDialog.ShowDialog(_mainWindow);
+            var progressDialog = new ProgressDialogViewModel(new List<Progress<KeyValuePair<int, string>>>() { 
+                progressBlock1, progressBlock2, progressDecryptBlock2 }, this);
+            progressDialog.ShowDialog();
+            
 
             var iukData = await SQRL.DecryptBlock2(
                 this.Identity, SQRL.CleanUpRescueCode(this.RescueCode), progressDecryptBlock2);
@@ -146,7 +147,7 @@ namespace SQRLDotNetClientUI.ViewModels
                 var block1 = SQRL.GenerateIdentityBlock1(iukData.Iuk, this.NewPassword, newId, progressBlock1);
                 var block2 = SQRL.GenerateIdentityBlock2(iukData.Iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
                 await Task.WhenAll(block1, block2);
-
+                
                 progressDialog.Close();
 
                 if (newId.HasBlock(3)) SQRL.GenerateIdentityBlock3(iukData.Iuk, this.Identity, newId, imk, imk); 
@@ -172,6 +173,7 @@ namespace SQRLDotNetClientUI.ViewModels
             }
             else
             {
+                
                 progressDialog.Close();
 
                 var btnRsult = await new Views.MessageBox(

--- a/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
@@ -22,7 +22,11 @@ namespace SQRLDotNetClientUI.ViewModels
         public ViewModelBase Content
         {
             get => content;
-            set { PriorContent = Content; this.RaiseAndSetIfChanged(ref content, value); }
+            set { 
+            
+                PriorContent = (value.GetType() != typeof(ProgressDialogViewModel) && Content!=null && Content.GetType() != typeof(ProgressDialogViewModel) ? Content : PriorContent); 
+                this.RaiseAndSetIfChanged(ref content, value); 
+            }
         }
 
         public ViewModelBase PriorContent

--- a/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
@@ -23,7 +23,7 @@ namespace SQRLDotNetClientUI.ViewModels
         {
             get => content;
             set { 
-            
+                // Don't want PriorContent to be messed up because of the progress indicator so we aren't counting those
                 PriorContent = (value.GetType() != typeof(ProgressDialogViewModel) && Content!=null && Content.GetType() != typeof(ProgressDialogViewModel) ? Content : PriorContent); 
                 this.RaiseAndSetIfChanged(ref content, value); 
             }

--- a/SQRLDotNetClientUI/ViewModels/NewIdentityVerifyViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/NewIdentityVerifyViewModel.cs
@@ -44,14 +44,16 @@ namespace SQRLDotNetClientUI.ViewModels
         {
             var progressBlock1 = new Progress<KeyValuePair<int, string>>();
             var progressBlock2 = new Progress<KeyValuePair<int, string>>();
-            var progressDialog = new ProgressDialog(new List<Progress<KeyValuePair<int, string>>>() {
-                    progressBlock1, progressBlock2});
-            _ = progressDialog.ShowDialog(_mainWindow);
+            var progressDialog = new ProgressDialogViewModel(new List<Progress<KeyValuePair<int, string>>>() {
+                    progressBlock1, progressBlock2},this);
+            progressDialog.ShowDialog();
+            
 
             var block1Task = SQRL.DecryptBlock1(this.Identity, this.Password, progressBlock1);
             var block2Task = SQRL.DecryptBlock2(this.Identity, SQRL.CleanUpRescueCode(this.RescueCode), progressBlock2);
             await Task.WhenAll(block1Task, block2Task);
 
+            
             progressDialog.Close();
 
             string msg = "";

--- a/SQRLDotNetClientUI/ViewModels/NewIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/NewIdentityViewModel.cs
@@ -89,9 +89,12 @@ namespace SQRLDotNetClientUI.ViewModels
 
             var progressBlock1 = new Progress<KeyValuePair<int, string>>();
             var progressBlock2 = new Progress<KeyValuePair<int, string>>();
-            var progressDialog = new ProgressDialog(new List<Progress<KeyValuePair<int, string>>>() {
-                progressBlock1, progressBlock2});
-            _ = progressDialog.ShowDialog(_mainWindow);
+
+            var progressDialog = new ProgressDialogViewModel(new List<Progress<KeyValuePair<int, string>>>() {
+                progressBlock1, progressBlock2}, this);
+            
+            
+            progressDialog.ShowDialog();
 
             newId = SQRL.GenerateIdentityBlock0(imk, newId);
             newId = await SQRL.GenerateIdentityBlock1(iuk, this.NewPassword, newId, progressBlock1);
@@ -101,12 +104,15 @@ namespace SQRLDotNetClientUI.ViewModels
                 newId = await SQRL.GenerateIdentityBlock2(iuk, SQRL.CleanUpRescueCode(this.RescueCode), newId, progressBlock2);
                 if (newId.Block2 != null)
                 {
+                    
                     progressDialog.Close();
+                    
 
                     ((MainWindowViewModel)_mainWindow.DataContext).Content = 
                         new NewIdentityVerifyViewModel(newId, this.NewPassword);
                 }
             }
+            
             progressDialog.Close();
         }
 

--- a/SQRLDotNetClientUI/ViewModels/ProgressDialogViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ProgressDialogViewModel.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SQRLDotNetClientUI.ViewModels
+{
+    public class ProgressDialogViewModel: ViewModelBase
+    {
+        public List<Progress<KeyValuePair<int, string>>> ProgressList { get; set; }
+        public ViewModelBase Parent { get; set; }
+
+        public bool HideFinishedItems { get; set; }
+        public bool HideEnqueuedItems { get; set; }
+
+        
+
+        private ProgressDialogViewModel()
+        {
+            
+        }
+        private ProgressDialogViewModel(ViewModelBase model, bool HideFinishedItems = true, bool HideEnqueuedItems = true) :this()
+        {
+            this.Parent = model;
+            this.Title = this.Parent.Title;
+            this.HideFinishedItems = HideFinishedItems;
+            this.HideEnqueuedItems = HideEnqueuedItems;
+        }
+
+        public ProgressDialogViewModel(List<Progress<KeyValuePair<int, string>>> progressList, ViewModelBase model, bool HideFinishedItems = true, bool HideEnqueuedItems = true) :this(model, HideFinishedItems, HideEnqueuedItems)
+        {
+            this.ProgressList = progressList;
+
+        }
+
+        public ProgressDialogViewModel(Progress<KeyValuePair<int, string>> progress, ViewModelBase model, bool HideFinishedItems = false, bool HideEnqueuedItems = false) : this (model, HideFinishedItems, HideEnqueuedItems)
+        {
+            this.ProgressList = new List<Progress<KeyValuePair<int, string>>>();
+            this.ProgressList.Add(progress);
+        }
+
+        /// <summary>
+        /// Sets the current progress dialog as the forground User Control
+        /// </summary>
+        public void ShowDialog()
+        {
+            ((MainWindowViewModel)_mainWindow.DataContext).Content = this;
+        }
+
+
+        /// <summary>
+        /// Sets the Parent of the Progress Dialog back to the Foreground control.
+        /// </summary>
+        public void Close()
+        {
+            if(((MainWindowViewModel)_mainWindow.DataContext).Content==this)
+                ((MainWindowViewModel)_mainWindow.DataContext).Content = this.Parent;
+        }
+    }
+}

--- a/SQRLDotNetClientUI/ViewModels/ReKeyViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ReKeyViewModel.cs
@@ -109,8 +109,7 @@ namespace SQRLDotNetClientUI.ViewModels
 
             //Progress Dialog will show our "Progress" as the Identity is Decrypted, and Re-Encrypted for Rekey
             var progressDialog = new ProgressDialogViewModel(progressList,this,true,true);
-            progressDialog.HideFinishedItems = true;
-            progressDialog.HideEnqueuedItems = true;
+            
             
             progressDialog.ShowDialog();
 

--- a/SQRLDotNetClientUI/Views/ProgressDialog.xaml.cs
+++ b/SQRLDotNetClientUI/Views/ProgressDialog.xaml.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 
 namespace SQRLDotNetClientUI.Views
 {
-    /// <summary>
+    /// <summary> 
     /// A dialog window to display an arbitrary number of progess indicators.
     /// Progress items can be added through the constructor or passed in
     /// using the <c>AddProgressItem()</c> method.

--- a/SQRLDotNetClientUI/Views/ProgressDialogView.xaml
+++ b/SQRLDotNetClientUI/Views/ProgressDialogView.xaml
@@ -1,17 +1,14 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+﻿<UserControl xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
         xmlns:loc="clr-namespace:SQRLCommonUI.AvaloniaExtensions;assembly=SQRLCommonUI"
-        Icon="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico"
+        
         mc:Ignorable="d" d:DesignWidth="350"
-        Width="350" 
-        x:Class="SQRLDotNetClientUI.Views.ProgressDialog"
-        Title="{loc:Localization ProgressDialogTitle}"
-        WindowStartupLocation="CenterOwner"
-        CanResize="False"
-        SizeToContent="Height">
+        x:Class="SQRLDotNetClientUI.Views.ProgressDialogView"
+        
+        >
 
   <DockPanel Margin="20,20,20,40">
     <StackPanel Name="MainPanel" DockPanel.Dock="Top" Orientation="Vertical">
@@ -27,4 +24,4 @@
     </StackPanel>
   </DockPanel>
   
-</Window>
+</UserControl>

--- a/SQRLDotNetClientUI/Views/ProgressDialogView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/ProgressDialogView.xaml.cs
@@ -87,6 +87,11 @@ namespace SQRLDotNetClientUI.Views
             this.DataContextChanged += ProgressDialog_DataContextChanged;
         }
 
+        /// <summary>
+        /// When the Progress Dialog View Model is attached to the ProgresDialogView we need to iterate and add the Progress Items
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void ProgressDialog_DataContextChanged(object sender, EventArgs e)
         {
             if (this.DataContext != null)

--- a/SQRLDotNetClientUI/Views/ProgressDialogView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/ProgressDialogView.xaml.cs
@@ -102,28 +102,7 @@ namespace SQRLDotNetClientUI.Views
             }
         }
 
-        /// <summary>
-        /// Creates a new <c>ProgressDialog</c> instance and adds the provided progress items
-        /// containted in <paramref name="progressList"/>.
-        /// </summary>
-        /// <param name="progressList">A list of progress items to track.</param>
-        public ProgressDialogView(List<Progress<KeyValuePair<int, string>>> progressList) : this()
-        {
-            foreach(var progress in progressList)
-            {
-                AddProgressItem(progress);
-            }
-        }
-
-        /// <summary>
-        /// Creates a new <c>ProgressDialog</c> instance and adds the provided progress item
-        /// <paramref name="progress"/>.
-        /// </summary>
-        /// <param name="progressList">The progress item to track.</param>
-        public ProgressDialogView(Progress<KeyValuePair<int, string>> progress) : this()
-        {
-            AddProgressItem(progress);
-        }
+        
 
         /// <summary>
         /// Adds a progress item to the progress dialog.


### PR DESCRIPTION
This pull request moves the Progress Indicator Dialog to a User Control and replaces it's usage everywhere. I tried to keep some of the prior "Dialog" Syntax 
So I implemented 
ShowDialog()
and Close() so the code is pretty similar to what it was.
![NewProgress](https://user-images.githubusercontent.com/420837/78504795-46a2b480-773d-11ea-811a-a6c1f321a1c1.gif)

Let me know how you feel about it @alexhauser  we can always change some things, this works better in the Mac and Linux because you don't have to worry about Window Placement and Positioning which isn't supported in some of those.

**Linux Before**
![LinuxBefore](https://user-images.githubusercontent.com/420837/78505014-7b633b80-773e-11ea-9ce9-a2ab594e0234.gif)


**Linux After**

![LinuxAfter](https://user-images.githubusercontent.com/420837/78505023-8918c100-773e-11ea-9419-80567c15062b.gif)
