### PR TITLE
Add "About" screen

### DIFF
--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -144,7 +144,13 @@
     { "IdentityDocumentQRCodeMessage": "This printed identity was encrypted with the password it had at the time, and also with its permanent Rescue Code. Since either the correct Password, or the identity's Rescue Code, will allow this identity to be used by anyone, neither of those should be stored with, or in any way available with, this printed identity:" },
     { "IdentityDocumentTextualIdentityMessage": "As an additional recovery measure, a textual version of this identity is provided below. If a camera is not available to scan and import the QR code above, the text below may be entered for full identity recovery. However, this is a Rescue Code ONLY version, so this identity's Rescue Code will be required for its decryption:" },
     { "IdentityDocumentGuidanceMessage": "Please retain and protect this printed version of your identity. With SQRL's “two-party” operation, no one can compromise your SQRL logon security. But this also means that there is no one to turn to if your identity is somehow lost or misplaced. Please treat this identity with the care it deserves. It is your secure and private key to the Internet." },
-    { "BtnSaveAsPdf": "Save as PDF" }
+    { "BtnSaveAsPdf": "Save as PDF" },
+    { "AboutWindowTitle": "About" },
+    { "VersionLabel": "Version" },
+    { "AboutText": "This program is Open Source Software and released under an open license.\r\n\r\nYou can find the source code as well as the license on Github:" },
+    { "BtnViewRepository": "View Repository" },
+    { "BtnViewLicense": "View License" },
+    { "OpenSourceLicenses": "Open source licenses / used libraries:" }
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -290,7 +296,13 @@
     { "IdentityDocumentQRCodeMessage": "This printed identity was encrypted with the password it had at the time, and also with its permanent Rescue Code. Since either the correct Password, or the identity's Rescue Code, will allow this identity to be used by anyone, neither of those should be stored with, or in any way available with, this printed identity:" },
     { "IdentityDocumentTextualIdentityMessage": "As an additional recovery measure, a textual version of this identity is provided below. If a camera is not available to scan and import the QR code above, the text below may be entered for full identity recovery. However, this is a Rescue Code ONLY version, so this identity's Rescue Code will be required for its decryption:" },
     { "IdentityDocumentGuidanceMessage": "Please retain and protect this printed version of your identity. With SQRL's “two-party” operation, no one can compromise your SQRL logon security. But this also means that there is no one to turn to if your identity is somehow lost or misplaced. Please treat this identity with the care it deserves. It is your secure and private key to the Internet." },
-    { "BtnSaveAsPdf": "Save as PDF" }
+    { "BtnSaveAsPdf": "Save as PDF" },
+    { "AboutWindowTitle": "About" },
+    { "VersionLabel": "Version" },
+    { "AboutText": "This program is Open Source Software and released under an open license.\r\n\r\nYou can find the source code as well as the license on Github:" },
+    { "BtnViewRepository": "View Repository" },
+    { "BtnViewLicense": "View License" },
+    { "OpenSourceLicenses": "Open source licenses / used libraries:" }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -436,6 +448,12 @@
     { "IdentityDocumentQRCodeMessage": "This printed identity was encrypted with the password it had at the time, and also with its permanent Rescue Code. Since either the correct Password, or the identity's Rescue Code, will allow this identity to be used by anyone, neither of those should be stored with, or in any way available with, this printed identity:" },
     { "IdentityDocumentTextualIdentityMessage": "As an additional recovery measure, a textual version of this identity is provided below. If a camera is not available to scan and import the QR code above, the text below may be entered for full identity recovery. However, this is a Rescue Code ONLY version, so this identity's Rescue Code will be required for its decryption:" },
     { "IdentityDocumentGuidanceMessage": "Please retain and protect this printed version of your identity. With SQRL's “two-party” operation, no one can compromise your SQRL logon security. But this also means that there is no one to turn to if your identity is somehow lost or misplaced. Please treat this identity with the care it deserves. It is your secure and private key to the Internet." },
-    { "BtnSaveAsPdf": "Als PDF speichern" }
+    { "BtnSaveAsPdf": "Als PDF speichern" },
+    { "AboutWindowTitle": "Über" },
+    { "VersionLabel": "Version" },
+    { "AboutText": "Dieses Programm ist Open Source Software und wird unter einer offenen Lizenz veröffentlicht.\r\n\r\nSie finden sowohl den Quellcode als auch die Lizenz auf Github:" },
+    { "BtnViewRepository": "Zum Repository" },
+    { "BtnViewLicense": "Lizenz anzeigen" },
+    { "OpenSourceLicenses": "Open-Source-Lizenzen / Libraries:" }
   ]
 }

--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -4,8 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon>Assets\sqrl_icon_normal_256.ico</ApplicationIcon>
     <Version>0.0.1</Version>
-    <AssemblyVersion>0.0.1.1</AssemblyVersion>
-    <FileVersion>0.0.1.1</FileVersion>
+    <AssemblyVersion>0.1.1.0</AssemblyVersion>
+    <FileVersion>0.1.1.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <TrimmerRootAssembly Include="mscorlib" />
@@ -51,6 +51,7 @@
     <AvaloniaResource Remove="Assets\SQRL_icon_normal_64.png" />
     <AvaloniaResource Remove="Assets\SQRL_InAction.gif" />
     <AvaloniaResource Remove="Assets\VL.png" />
+    <AvaloniaResource Remove="Views\AboutView.xaml" />
     <AvaloniaResource Remove="Views\AskView.xaml" />
     <AvaloniaResource Remove="Views\AuthenticationView.xaml" />
     <AvaloniaResource Remove="Views\ChangePasswordView.xaml" />
@@ -93,6 +94,7 @@
     <None Remove="Assets\sqrl_icon_normal_48_icon.ico" />
     <None Remove="Assets\SQRL_icon_normal_64.png" />
     <None Remove="Assets\VL.png" />
+    <None Remove="Views\AboutView.xaml" />
     <None Remove="Views\AskView.xaml" />
     <None Remove="Views\AuthenticationView.xaml" />
     <None Remove="Views\ChangePasswordView.xaml" />
@@ -274,6 +276,11 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Views\NewPasswordWidget.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Views\AboutView.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/SQRLDotNetClientUI/ViewModels/AboutViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AboutViewModel.cs
@@ -1,0 +1,72 @@
+﻿using ReactiveUI;
+using Serilog;
+using System.Diagnostics;
+using System.Reflection;
+
+namespace SQRLDotNetClientUI.ViewModels
+{
+    /// <summary>
+    /// A view model representing the app's "About" screen.
+    /// </summary>
+    public class AboutViewModel : ViewModelBase
+    {
+        private string _appVersion;
+
+        /// <summary>
+        /// Gets or sets the app's executable version.
+        /// </summary>
+        public string AppVersion
+        {
+            get => _appVersion;
+            set => this.RaiseAndSetIfChanged(ref _appVersion, value);
+        }
+
+        /// <summary>
+        /// Creates a new instance, sets the window title and performs
+        /// a few initializations.
+        /// </summary>
+        public AboutViewModel()
+        {
+            var assemblyName = Assembly.GetExecutingAssembly().GetName();
+
+            this.Title = _loc.GetLocalizationValue("AboutWindowTitle") + " " +
+                assemblyName.Name;
+
+            this.AppVersion = _loc.GetLocalizationValue("VersionLabel") + ": " +
+                assemblyName.Version.ToString();
+        }
+
+        /// <summary>
+        /// Navigates back to the app's main screen.
+        /// </summary>
+        public void Back()
+        {
+            Log.Information("Leaving about screen");
+
+            ((MainWindowViewModel)_mainWindow.DataContext).Content =
+                new MainMenuViewModel();
+        }
+
+        /// <summary>
+        /// Starts a browser window with a link to the repo on Github.
+        /// </summary>
+        public void ShowRepository()
+        {
+            Process p = new Process();
+            p.StartInfo.UseShellExecute = true;
+            p.StartInfo.FileName = @"https://github.com/sqrldev/SQRLDotNetClient";
+            p.Start();
+        }
+
+        /// <summary>
+        /// Starts a browser window with a link to the repo on Github.
+        /// </summary>
+        public void ShowLicense()
+        {
+            Process p = new Process();
+            p.StartInfo.UseShellExecute = true;
+            p.StartInfo.FileName = @"https://raw.githubusercontent.com/sqrldev/SQRLDotNetClient/master/LICENSE";
+            p.Start();
+        }
+    }
+}

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -190,6 +190,14 @@ namespace SQRLDotNetClientUI.ViewModels
                 new ChangePasswordViewModel();
         }
 
+        public void About()
+        {
+            Log.Information("Launching about screen");
+
+            ((MainWindowViewModel)_mainWindow.DataContext).Content =
+                new AboutViewModel();
+        }
+
         public void Exit()
         {
             _mainWindow.Close();

--- a/SQRLDotNetClientUI/Views/AboutView.xaml
+++ b/SQRLDotNetClientUI/Views/AboutView.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
+             xmlns:behaviors="clr-namespace:SQRLDotNetClientUI.Behaviors;assembly=SQRLDotNetClientUI"
+             xmlns:loc="clr-namespace:SQRLCommonUI.AvaloniaExtensions;assembly=SQRLCommonUI"
+             xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+             x:Class="SQRLDotNetClientUI.Views.AboutView">
+
+  <DockPanel LastChildFill="False" Margin="20,30,20,20">
+    
+    <ScrollViewer DockPanel.Dock="Top">
+      <StackPanel>
+        <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="40" HorizontalAlignment="Center" />
+        <TextBlock Text="{loc:Localization SQRLTag}" TextAlignment="Center" FontSize="14" FontWeight="Bold" Width="340" MaxWidth="340" Margin="10,20,10,10" FontFamily="resm:SQRLDotNetClientUI.Assets.Fonts.SpaceMono-Regular.ttf" TextWrapping="Wrap"/>
+        <TextBlock Text="{Binding AppVersion}" TextAlignment="Center" FontSize="12" Margin="10,0,10,10" Width="340" MaxWidth="340" TextWrapping="Wrap"/>
+        <TextBlock Text="{loc:Localization AboutText}" TextAlignment="Center" FontSize="12" Margin="10" Width="340" MaxWidth="340" TextWrapping="Wrap"/>
+        <Button Content="{loc:Localization BtnViewRepository}" Command="{Binding ShowRepository}" Margin="0,5" Width="250" MaxWidth="250" HorizontalAlignment="Center"/>
+        <Button Content="{loc:Localization BtnViewLicense}" Command="{Binding ShowLicense}" Width="250" MaxWidth="250" Margin="0,5" HorizontalAlignment="Center"/>
+
+        <!-- Listing all the used libraries and their licenses will follow later!
+        <TextBlock Text="{loc:Localization OpenSourceLicenses}" TextAlignment="Center" FontSize="12" FontWeight="Bold" Margin="10,20" Width="340" MaxWidth="340" TextWrapping="Wrap"/>
+        -->
+      </StackPanel>
+    </ScrollViewer>
+    
+    <Button Content="{loc:Localization BtnBack}" DockPanel.Dock="Bottom" Command="{Binding Back}" Margin="0,10" HorizontalAlignment="Center"/>
+    
+  </DockPanel>  
+    
+</UserControl>

--- a/SQRLDotNetClientUI/Views/AboutView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/AboutView.xaml.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace SQRLDotNetClientUI.Views
+{
+    public class AboutView : UserControl
+    {
+        public AboutView()
+        {
+            this.InitializeComponent();
+        }
+
+        private void InitializeComponent()
+        {
+            AvaloniaXamlLoader.Load(this);
+        }
+    }
+}

--- a/SQRLDotNetClientUI/Views/MainMenuView.xaml
+++ b/SQRLDotNetClientUI/Views/MainMenuView.xaml
@@ -34,7 +34,7 @@
       </MenuItem>
       <MenuItem Header="{loc:Localization HelpMenuItemHeader}" >
         <MenuItem Header="{loc:Localization CheckForUpdates}" IsEnabled="True" Command="{Binding CheckForUpdates}" />
-        <MenuItem Header="{loc:Localization AboutMenuItemHeader}" />
+        <MenuItem Header="{loc:Localization AboutMenuItemHeader}" Command="{Binding About}"/>
       </MenuItem>
     </Menu>
 

--- a/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
+++ b/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
@@ -49,6 +49,7 @@
     <AvaloniaResource Remove="Assets\unknown.png" />
     <AvaloniaResource Remove="Assets\VL.png" />
     <AvaloniaResource Remove="Assets\windows.png" />
+    <AvaloniaResource Remove="Views\AboutView.xaml" />
     <AvaloniaResource Remove="Views\InstallationCompleteView.xaml" />
     <AvaloniaResource Remove="Views\MainInstallView.xaml" />
     <AvaloniaResource Remove="Views\VersionSelectorView.xaml" />
@@ -76,6 +77,7 @@
     <None Remove="Assets\unknown.png" />
     <None Remove="Assets\VL.png" />
     <None Remove="Assets\windows.png" />
+    <None Remove="Views\AboutView.xaml" />
     <None Remove="Views\InstallationCompleteView.xaml" />
     <None Remove="Views\MainInstallView.xaml" />
     <None Remove="Views\VersionSelectorView.xaml" />
@@ -137,6 +139,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Views\AboutView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\GithubAPI\GithubAPI.csproj" />
     <ProjectReference Include="..\SQRLCommonUI\SQRLCommonUI.csproj" />
   </ItemGroup>
@@ -146,6 +153,9 @@
   <ItemGroup>
     <Compile Update="Views\MainInstallView.xaml.cs">
       <DependentUpon>MainInstallView.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="Views\AboutView.xaml.cs">
+      <DependentUpon>AboutView.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>

--- a/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
+++ b/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
@@ -49,7 +49,6 @@
     <AvaloniaResource Remove="Assets\unknown.png" />
     <AvaloniaResource Remove="Assets\VL.png" />
     <AvaloniaResource Remove="Assets\windows.png" />
-    <AvaloniaResource Remove="Views\AboutView.xaml" />
     <AvaloniaResource Remove="Views\InstallationCompleteView.xaml" />
     <AvaloniaResource Remove="Views\MainInstallView.xaml" />
     <AvaloniaResource Remove="Views\VersionSelectorView.xaml" />
@@ -77,7 +76,6 @@
     <None Remove="Assets\unknown.png" />
     <None Remove="Assets\VL.png" />
     <None Remove="Assets\windows.png" />
-    <None Remove="Views\AboutView.xaml" />
     <None Remove="Views\InstallationCompleteView.xaml" />
     <None Remove="Views\MainInstallView.xaml" />
     <None Remove="Views\VersionSelectorView.xaml" />
@@ -139,11 +137,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Views\AboutView.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\GithubAPI\GithubAPI.csproj" />
     <ProjectReference Include="..\SQRLCommonUI\SQRLCommonUI.csproj" />
   </ItemGroup>
@@ -153,9 +146,6 @@
   <ItemGroup>
     <Compile Update="Views\MainInstallView.xaml.cs">
       <DependentUpon>MainInstallView.xaml</DependentUpon>
-    </Compile>
-    <Compile Update="Views\AboutView.xaml.cs">
-      <DependentUpon>AboutView.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Ticks a box in #96.

### Description:
This adds a simple "About" screen which displays version and licensing information and provides a link to the repository on Github.

I plan to add information about the use of 3rd party libraries and their respective license information to that screen sometime in the future.

Also, the `AssemblyVersion` as well as `FileVersion` is set to 0.1.1.0 to match the current status quo of the Github releases.

![about_screen](https://user-images.githubusercontent.com/4005543/79224461-66cc2500-7e5b-11ea-806e-6d389d31342e.PNG)
