### PR TITLE
Turn "Switch identity" dialog into a UserControl

### DIFF
--- a/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
+++ b/SQRLDotNetClientUI/SQRLDotNetClientUI.csproj
@@ -67,7 +67,7 @@
     <AvaloniaResource Remove="Views\NewPasswordWidget.xaml" />
     <AvaloniaResource Remove="Views\ProgressDialogView.xaml" />
     <AvaloniaResource Remove="Views\ReKeyView.xaml" />
-    <AvaloniaResource Remove="Views\SelectIdentityDialogView.xaml" />
+    <AvaloniaResource Remove="Views\SelectIdentityView.xaml" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Assets\Fonts\SpaceMono-Bold.ttf" />
@@ -125,7 +125,7 @@
     <None Remove="Views\NewPasswordWidget.xaml" />
     <None Remove="Views\ProgressDialogView.xaml" />
     <None Remove="Views\ReKeyView.xaml" />
-    <None Remove="Views\SelectIdentityDialogView.xaml" />
+    <None Remove="Views\SelectIdentityView.xaml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Assets\Fonts\SpaceMono-Bold.ttf" />
@@ -275,12 +275,15 @@
     <Compile Update="Views\ProgressDialogView.xaml.cs">
       <DependentUpon>ProgressDialogView.xaml</DependentUpon>
     </Compile>
+    <Compile Update="Views\SelectIdentityView.xaml.cs">
+      <DependentUpon>SelectIdentityView.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Migrations\" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="Views\SelectIdentityDialogView.xaml">
+    <EmbeddedResource Include="Views\SelectIdentityView.xaml">
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -183,13 +183,9 @@ namespace SQRLDotNetClientUI.ViewModels
         /// <summary>
         /// Opens the identity selection dialog.
         /// </summary>
-        public async void SwitchIdentity()
+        public void SwitchIdentity()
         {
-            SelectIdentityDialogView selectIdDialog = new SelectIdentityDialogView
-            {
-                WindowStartupLocation = WindowStartupLocation.CenterOwner
-            };
-            await selectIdDialog.ShowDialog(_mainWindow);
+            new SelectIdentityViewModel().ShowDialog(this);
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -160,15 +160,14 @@ namespace SQRLDotNetClientUI.ViewModels
                 new ImportIdentityViewModel();
         }
 
-        public async void SwitchIdentity()
+        /// <summary>
+        /// Opens the identity selection dialog.
+        /// </summary>
+        public void SwitchIdentity()
         {
             if (_identityManager.IdentityCount > 1)
             {
-                SelectIdentityDialogView selectIdentityDialog = new SelectIdentityDialogView
-                {
-                    WindowStartupLocation = WindowStartupLocation.CenterOwner
-                };
-                await selectIdentityDialog.ShowDialog(_mainWindow);
+                new SelectIdentityViewModel().ShowDialog(this);
             }
         }
 

--- a/SQRLDotNetClientUI/ViewModels/SelectIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/SelectIdentityViewModel.cs
@@ -1,0 +1,44 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace SQRLDotNetClientUI.ViewModels
+{
+    /// <summary>
+    /// Represents a view model for the <c>SelectIdentityView</c> screen.
+    /// </summary>
+    public class SelectIdentityViewModel : ViewModelBase
+    {
+        private AutoResetEvent _identitySelected = null;
+        private ViewModelBase _parent = null;
+
+        public SelectIdentityViewModel()
+        {
+            _identitySelected = new AutoResetEvent(false);
+        }
+
+        /// <summary>
+        /// Handles the event of an identity being selected.
+        /// </summary>
+        public void OnIdentitySelected(string identityUniqueId)
+        {
+            _identityManager.SetCurrentIdentity(identityUniqueId);
+
+            // Signal the auto reset event that we're done
+            _identitySelected.Set();
+        }
+
+        public async void ShowDialog(ViewModelBase Parent)
+        {
+            this._parent = Parent;
+            
+            // Set the content of the main window to the select identity screen
+            ((MainWindowViewModel)_mainWindow.DataContext).Content = this;
+            
+            // Wait for an identity to get selected
+            await Task.Run(() => _identitySelected.WaitOne());
+
+            // Set the content of the main window back to where it was before
+            ((MainWindowViewModel)_mainWindow.DataContext).Content = _parent;
+        }
+    }
+}

--- a/SQRLDotNetClientUI/Views/SelectIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/SelectIdentityView.xaml
@@ -1,15 +1,12 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:loc="clr-namespace:SQRLCommonUI.AvaloniaExtensions;assembly=SQRLCommonUI"
-        mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
-        x:Class="SQRLDotNetClientUI.Views.SelectIdentityDialogView"
-        Icon="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico"
-        Title="{loc:Localization SelectIdentityTitle}"
-        Width="400"
-        Height="450"
-        CanResize="False">
+﻿<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
+             xmlns:v="clr-namespace:SQRLDotNetClientUI.Views;assembly=SQRLDotNetClientUI"
+             xmlns:loc="clr-namespace:SQRLCommonUI.AvaloniaExtensions;assembly=SQRLCommonUI"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
+             x:Class="SQRLDotNetClientUI.Views.SelectIdentityView">
   
   <!-- Layout start -->
     <StackPanel Margin="20" Orientation="Vertical">
@@ -25,4 +22,4 @@
       </ScrollViewer>
     </StackPanel>
 
-</Window>
+</UserControl>

--- a/SQRLDotNetClientUI/Views/SelectIdentityView.xaml.cs
+++ b/SQRLDotNetClientUI/Views/SelectIdentityView.xaml.cs
@@ -1,26 +1,22 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
 using Avalonia.Markup.Xaml;
 using SQRLDotNetClientUI.Models;
+using SQRLDotNetClientUI.ViewModels;
 using System;
 
 namespace SQRLDotNetClientUI.Views
 {
-    public class SelectIdentityDialogView : Window
+    public class SelectIdentityView : UserControl
     {
         private StackPanel _stackPnlMain = null;
         private IdentityManager _identityManager = IdentityManager.Instance;
 
-        public SelectIdentityDialogView()
+        public SelectIdentityView()
         {
             this.InitializeComponent();
-
-            this._stackPnlMain = this.FindControl<StackPanel>("stackPnlMain");
             PopulateUI();
-
-#if DEBUG
-            this.AttachDevTools();
-#endif
         }
 
         private void InitializeComponent()
@@ -33,6 +29,7 @@ namespace SQRLDotNetClientUI.Views
         /// </summary>
         private void PopulateUI()
         {
+            _stackPnlMain = this.FindControl<StackPanel>("stackPnlMain");
             var currentId = _identityManager.CurrentIdentity;
             var currentIdUniqueId = _identityManager.CurrentIdentityUniqueId;
             var ids = _identityManager.GetIdentities();
@@ -62,16 +59,15 @@ namespace SQRLDotNetClientUI.Views
         }
 
         /// <summary>
-        /// Handles the event of an identity getting selected.
+        /// Event handler that gets called when an identity gets selected.
         /// </summary>
-        private void OnIdentitySelected(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+        private void OnIdentitySelected(object sender, RoutedEventArgs e)
         {
             RadioButton rb = (RadioButton)sender;
             (string name, string uniqueId) = (Tuple<string, string>)rb.Tag;
 
-            _identityManager.SetCurrentIdentity(uniqueId);
-
-            this.Close();
+            SelectIdentityViewModel viewModel = (SelectIdentityViewModel)this.DataContext;
+            viewModel.OnIdentitySelected(uniqueId);
         }
     }
 }


### PR DESCRIPTION
Closes #108.

### Description:
This turns the "switch identity" dialog, which was a separate window up until now, into a `UserControl`.