### PR TITLE
Version management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,4 @@ healthchecksdb
 # Misc project-specific files
 packages-microsoft-prod.deb
 .DS_Store
+GithubAuthToken.txt

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Avalonia.Controls;
 using SQRLDotNetClientUI.Models;
 using Serilog;
+using System.Reflection;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
@@ -156,7 +157,8 @@ namespace SQRLDotNetClientUI.ViewModels
 
         private async void CheckForUpdate()
         {
-            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates();
+            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates(
+                Assembly.GetExecutingAssembly().GetName().Version);
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -240,7 +240,8 @@ namespace SQRLDotNetClientUI.ViewModels
         public async void CheckForUpdates()
         {
 
-            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates();
+            this.NewUpdateAvailable = await GitHubApi.GitHubHelper.CheckForUpdates(
+                Assembly.GetExecutingAssembly().GetName().Version);
         }
 
 

--- a/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
+++ b/SQRLPlatformAwareInstaller/SQRLPlatformAwareInstaller.csproj
@@ -148,4 +148,9 @@
       <DependentUpon>MainInstallView.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <None Update="GithubAuthToken.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Closes #101.

### Description:
This updates the `GitHubHelper` class to handle the agreed upon version management scheme. The client now looks at it's own assembly version number when checking for updates instead of reading the version file. I left the writing of the version file in the installer though for backwards compatibility, we can remove this once we're down a few versions with both the installer and the client.

### Notes:
This also adds a more convenient way for authenticating to Github for development. Just place a file called `GithubAuthToken.txt` containing a Github personal access token in the format of `token 5c19b5ada557335de35ed54642c363f82ac1da18` in the root directory of the installer project. It will then be copied to the output directory during build and is used by the installer if present. I also added this file to the `.gitignore` file, so it should never get uploaded to Github.