### PR TITLE
Replace install instructions in README.md with link to newly created Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,100 +11,11 @@ An implementation of a fully-featured SQRL client, along with a cross-platform u
 
 
 
-#### Installing the Client on Linux (desktop environment / xdg-desktop is required)
+#### Installing the Client 
 
-```shell
-sudo apt-get install -y libgdiplus
-```
+Installation instructions for all supported platforms can be found in the project's Github Wiki at https://github.com/sqrldev/SQRLDotNetClient/wiki.
 
-
-- Go to the Latest Releases Page at: https://github.com/sqrldev/SQRLDotNetClient/releases
-- Select Assets
-- Download SQRLPlatformAwareInstaller_linux
-  ![image-20200406102440688](/SQRLDotNetClientUI/Assets/Linux_Installer.png)
-- Open Terminal and CD into your Download Location
-
-```shell
-chmod a+x ./SQRLPlatformAwareInstaller_linux
-./SQRLPlatformAwareInstaller_linux
-```
-
-- Follow the Installer Prompts
-
-#### Installing Client on MacOSX
-
-- Open Terminal
-
-```shell
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-
-brew install mono-libgdiplus
-```
-
-- Go to the Latest Releases at: https://github.com/sqrldev/SQRLDotNetClient/releases
-
-- Select Assets
-
-- Download: SQRLPlatformAwareInstaller_osx
-
-  ![image-20200406102814087](/SQRLDotNetClientUI/Assets/MacOsx_Installer.png)
-
-- Open Terminal
-
-- CD into the Downloads Folder
-
-  ```shell
-  chmod a+x ./SQRLPlatformAwareInstaller_osx.dms
-  ./SQRLPlatformAwareInstaller_osx.dms
-  ```
-
-- You may get a security prompt at this point about unknown developer
-
-  ![image-20200406103148991](/SQRLDotNetClientUI/Assets/Mac_Error1.png)
-
-- Click Cancel
-
-- Open System Preferences and Click Security and Privacy
-
-  ![image-20200406103317325](/SQRLDotNetClientUI/Assets/Mac_SecurityAndPrivacy.png)
-
-- You should see a message at the bottom regarding Blocked SQRL and a button that says Allow Anyways click that
-
-  ![image-20200406103421405](/SQRLDotNetClientUI/Assets/Mac_AllowAnyways.png)
-
-- Go back to the Terminal and Launch the Installer again
-
-  ```shell
-  ./SQRLPlatformAwareInstaller_osx.dms
-  ```
-
-- This time, on the message, click Open
-
-  ![image-20200406103539966](/SQRLDotNetClientUI/Assets/MacOsx_Error2.png)
-
-- Follow the Installer Prompts
-
-  ![image-20200406103648963](/SQRLDotNetClientUI/Assets/MacOsx_InstallerPrompt.png)
-
-#### Install Client on Windows OS
-
-- Download the latest Windows Client binary from the Github releases: [https://github.com/sqrldev/SQRLDotNetClient/releases](https://github.com/sqrldev/SQRLDotNetClient/releases)
-
-- Download: SQRLPlatformAwareInstaller_win.exe
-
-  ![image-20200406103803339](/SQRLDotNetClientUI/Assets/WinInstaller.png)
-
-- Run SQRLPlatformAwareInstaller_win.exe
-
-- If Prompted by UAC Click Run Anyway
-
-  ![image-20200406103923048](/SQRLDotNetClientUI/Assets/WinRunAnyways.png)
-
-- Follow Installer Prompts
-
-  ![image-20200406104037042](/SQRLDotNetClientUI/Assets/WinInstallerPrompt.png)
-
-### Enjoy your new SQRL Client
+Enjoy your new SQRL Client!
 
 ![](/SQRLDotNetClientUI/Assets/NewIdentitySetup.gif)
 


### PR DESCRIPTION
### Description:
This replaces the lengthy install instructions in the README.md with a link to the newly created pages in the project's Github Wiki at https://github.com/sqrldev/SQRLDotNetClient/wiki.

This aims at de-cluttering the README and give a better "first glimpse" of the whole project without overwhelming the visitor.