### PR TITLE
Fix flaws in "Import Identity"

### DIFF
--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -150,7 +150,8 @@
     { "BtnViewRepository": "View Repository" },
     { "BtnViewLicense": "View License" },
     { "OpenSourceLicenses": "Open source licenses / used libraries:" },
-    { "SaveRescueCodeDialogTitle": "Select a location and name to save your rescue code" }
+    { "SaveRescueCodeDialogTitle": "Select a location and name to save your rescue code" },
+    { "OrLabel": "... or ..."}
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -303,7 +304,8 @@
     { "BtnViewRepository": "View Repository" },
     { "BtnViewLicense": "View License" },
     { "OpenSourceLicenses": "Open source licenses / used libraries:" },
-    { "SaveRescueCodeDialogTitle": "Select a location and name to save your rescue code" }
+    { "SaveRescueCodeDialogTitle": "Select a location and name to save your rescue code" },
+    { "OrLabel": "... or ..." }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -456,6 +458,7 @@
     { "BtnViewRepository": "Zum Repository" },
     { "BtnViewLicense": "Lizenz anzeigen" },
     { "OpenSourceLicenses": "Open-Source-Lizenzen / Libraries:" },
-    { "SaveRescueCodeDialogTitle": "Wählen Sie einen Namen und Speicherort für Ihren Rettungscode" }
+    { "SaveRescueCodeDialogTitle": "Wählen Sie einen Namen und Speicherort für Ihren Rettungscode" },
+    { "OrLabel": "... oder ..." }
   ]
 }

--- a/SQRLDotNetClientUI/ViewModels/ImportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ImportIdentityViewModel.cs
@@ -16,22 +16,38 @@ namespace SQRLDotNetClientUI.ViewModels
             set { this.RaiseAndSetIfChanged(ref _textualIdentity, value); } 
         }
 
-        private string _identityFile="N/A";
+        private string _identityFile="";
         public string IdentityFile 
         {
             get => _identityFile; 
             set { this.RaiseAndSetIfChanged(ref _identityFile, value); } 
         }
-        
+
+        private bool _canImport = false;
+        public bool CanImport
+        {
+            get => _canImport;
+            set { this.RaiseAndSetIfChanged(ref _canImport, value); }
+        }
+
         public ImportIdentityViewModel()
         {
             this.Title = _loc.GetLocalizationValue("ImportIdentityWindowTitle");
+
+            this.WhenAnyValue(x => x.TextualIdentity, x => x.IdentityFile,
+                  (te, id) => new Tuple<string, string>(te, id))
+                .Subscribe((x) => 
+                {
+                    if (!string.IsNullOrEmpty(x.Item1) || !string.IsNullOrEmpty(x.Item2)) CanImport = true;
+                    else CanImport = false;
+                });
         }
 
         public async void ImportFile()
         {
             FileDialogFilter fdf = new FileDialogFilter();
             fdf.Extensions.Add("sqrl");
+            fdf.Extensions.Add("sqrc");
             fdf.Name = _loc.GetLocalizationValue("FileDialogFilterName");
 
             OpenFileDialog ofd = new OpenFileDialog
@@ -41,11 +57,11 @@ namespace SQRLDotNetClientUI.ViewModels
             ofd.Filters.Add(fdf);
             ofd.Title = _loc.GetLocalizationValue("ImportOpenFileDialogTitle");
 
-            var file = await ofd.ShowAsync(_mainWindow);
+            var files = await ofd.ShowAsync(_mainWindow);
 
-            if(file.Length>0)
+            if(files != null && files.Length>0)
             {
-                this.IdentityFile = file[0];
+                this.IdentityFile = files[0];
             }
         }
 

--- a/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using ReactiveUI;
+using SQRLDotNetClientUI.Views;
 
 namespace SQRLDotNetClientUI.ViewModels
 {
@@ -27,9 +28,20 @@ namespace SQRLDotNetClientUI.ViewModels
         public ViewModelBase Content
         {
             get => _content;
-            set { 
-                // Don't want PriorContent to be messed up because of the progress indicator so we aren't counting those
-                PriorContent = (value.GetType() != typeof(ProgressDialogViewModel) && Content!=null && Content.GetType() != typeof(ProgressDialogViewModel) ? Content : PriorContent); 
+            set 
+            { 
+                // Don't want PriorContent to be messed up because of the progress indicator
+                // or message boxes so we aren't counting those
+                if (Content != null &&
+                    Content != PriorContent &&
+                    Content.GetType() != typeof(ProgressDialogViewModel) &&
+                    Content.GetType() != typeof(MessageBoxViewModel) &&
+                    value.GetType() != typeof(ProgressDialogViewModel) &&
+                    value.GetType() != typeof(MessageBoxViewModel))
+                {
+                    PriorContent = Content;
+                }
+                 
                 this.RaiseAndSetIfChanged(ref _content, value); 
             }
         }

--- a/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
@@ -4,37 +4,26 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:SQRLDotNetClientUI.ViewModels;assembly=SQRLDotNetClientUI"
              xmlns:loc="clr-namespace:SQRLCommonUI.AvaloniaExtensions;assembly=SQRLCommonUI"
-             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="400"
+             mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="450"
              x:Class="SQRLDotNetClientUI.Views.ImportIdentityView">
-   
-  <Grid ShowGridLines="False" Width="400">
-    <Grid.ColumnDefinitions>
-      <ColumnDefinition Width="100" />
-      <ColumnDefinition Width="*" />
-    </Grid.ColumnDefinitions>
-    <Grid.RowDefinitions>
-      <RowDefinition Height="Auto" />
-      <RowDefinition Height="Auto"/>
-      <RowDefinition Height="Auto"/>    
-      <RowDefinition Height="Auto"/>
-    </Grid.RowDefinitions>
 
-    <Image Source="resm:SQRLDotNetClientUI.Assets.sqrl_icon_normal_48_icon.ico" Height="50" HorizontalAlignment="Right" 
-           VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Margin="10"></Image>
-    <TextBlock Margin="10" Text="{loc:Localization ImportIdentityMessage}" FontSize="15" TextWrapping="Wrap" Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"/>
-    
-    <StackPanel Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2">
-      <TextBlock Margin="10,10,10,5" FontWeight="Bold" Text="{loc:Localization TextualIdentityLabel}" FontSize="12" TextWrapping="Wrap" Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2" VerticalAlignment="Bottom"/>
-      <loc:CopyPasteTextBox Margin="10,0,10,10" Text="{Binding TextualIdentity}" Height="200" AcceptsReturn="True" TextWrapping="Wrap" />
+  <DockPanel LastChildFill="False" Margin="20">
+
+    <StackPanel DockPanel.Dock="Top" Orientation="Vertical">
+      
+      <TextBlock Text="{loc:Localization ImportIdentityMessage}" Margin="0,0,0,10" FontSize="12" TextWrapping="Wrap"/>
+      <TextBlock Text="{loc:Localization TextualIdentityLabel}" Margin="0,10" FontWeight="Bold" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Bottom"/>
+      <loc:CopyPasteTextBox Text="{Binding TextualIdentity}"  Margin="0,0,0,10" Height="200" AcceptsReturn="True" TextWrapping="Wrap" />
+      <TextBlock Text="{loc:Localization OrLabel}" Margin="0,0,0,10" FontSize="12"/>
+      <Button Name="btnImportFromFile" Content="{loc:Localization BtnImportFile}" Command="{Binding ImportFile}" HorizontalAlignment="Left" Height="25" Width="120" />
+      <TextBlock Text="{Binding IdentityFile}" Width="360" MaxWidth="360" Margin="0,5" FontWeight="Bold" FontSize="12" TextWrapping="Wrap" VerticalAlignment="Center"/>
+      
     </StackPanel>
-    
-    <Button Name="btnImportFromFile" Content="{loc:Localization BtnImportFile}" Command="{Binding ImportFile}" Grid.Row="2" Grid.Column="0" Height="25" Width="80" />
-    
-    <TextBlock Margin="10,10,10,5" FontWeight="Bold" Text="{Binding IdentityFile}"  FontSize="12" TextWrapping="Wrap" 
-               Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" VerticalAlignment="Center"/>
 
-    <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="5" Grid.Column="0" Width="70" HorizontalAlignment="Left" />
-    <Button Content="{loc:Localization BtnNext}" Command="{Binding ImportVerify}" IsEnabled="{Binding CanImport}" IsDefault="True" Margin="10" Grid.Row="5" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
+    <DockPanel DockPanel.Dock="Bottom">
+      <Button Content="{loc:Localization BtnCancel}" Command="{Binding Cancel}" DockPanel.Dock="Left" Width="90" HorizontalAlignment="Left" />
+      <Button Content="{loc:Localization BtnNext}" Command="{Binding ImportVerify}" IsEnabled="{Binding CanImport}" DockPanel.Dock="Right" IsDefault="True" Width="90" HorizontalAlignment="Right" />
+    </DockPanel>
     
-  </Grid>
+  </DockPanel>
 </UserControl>

--- a/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/ImportIdentityView.xaml
@@ -34,7 +34,7 @@
                Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="1" VerticalAlignment="Center"/>
 
     <Button Content="{loc:Localization BtnCancel}" Margin="10" Command="{Binding Cancel}" Grid.Row="5" Grid.Column="0" Width="70" HorizontalAlignment="Left" />
-    <Button Content="{loc:Localization BtnNext}" IsDefault="True" Margin="10" Command="{Binding ImportVerify}" Grid.Row="5" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
+    <Button Content="{loc:Localization BtnNext}" Command="{Binding ImportVerify}" IsEnabled="{Binding CanImport}" IsDefault="True" Margin="10" Grid.Row="5" Grid.Column="1" Width="70" HorizontalAlignment="Right" />
     
   </Grid>
 </UserControl>


### PR DESCRIPTION
Closes #120 

### Description/Fixes:

- Improve general layout of the "Import Identity" screen (get rid of `Grid`)
- Only enable the "Next" button when either a textual identity is given or a file was selected
- Allow import of `*.sqrc` files
- Fix "content/prior content" logic bug which would prevent a user from backing out of the screen once an error message was being displayed
