### PR TITLE
Add identity export options

### DIFF
--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -157,7 +157,10 @@
     { "StartMinimizedLabel": "Start with the app window minimized" },
     { "CPSAbortHeader": "Authentication Aborted" },
     { "CPSAbortMessage": "SQRL's CPS authentication has been aborted. You will be automatically sent back to the previous page in a few seconds. If this does not work, please press your browser's BACK button or click the link below." },
-    { "CPSAbortLinkText": "Go Back Now" }
+    { "CPSAbortLinkText": "Go Back Now" },
+    { "BtnShowQrCode": "Show QR Code" },
+    { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
+    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." }
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -317,7 +320,10 @@
     { "StartMinimizedLabel": "Start with the app window minimized" },
     { "CPSAbortHeader": "Authentication Aborted" },
     { "CPSAbortMessage": "SQRL's CPS authentication has been aborted. You will be automatically sent back to the previous page in a few seconds. If this does not work, please press your browser's BACK button or click the link below." },
-    { "CPSAbortLinkText": "Go Back Now" }
+    { "CPSAbortLinkText": "Go Back Now" },
+    { "BtnShowQrCode": "Show QR Code" },
+    { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
+    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -477,6 +483,9 @@
     { "StartMinimizedLabel": "Programmfenster beim Start minimieren" },
     { "CPSAbortHeader": "Authentifizierung abgebrochen" },
     { "CPSAbortMessage": "SQRLs CPS-Authentifizierung wurde abgebrochen. Sie werden in ein paar Sekunden automatisch zur vorherigen Seite zurückgeleitet. Falls dies nicht funktioniert, drücken Sie bitte in Ihrem Browser auf die Schaltfläche \"Zurück\" oder klicken Sie auf den folgenden Link." },
-    { "CPSAbortLinkText": "Jetzt zurückgehen" }
+    { "CPSAbortLinkText": "Jetzt zurückgehen" },
+    { "BtnShowQrCode": "QR-Code anzeigen" },
+    { "RadButExortWithPassword": "Erlaube Backup-Entschlüsselung mit Passwort oder Rettungscode für mehr Bequemlichkeit aber leicht reduzierte Sicherheit." },
+    { "RadButExortWithRescueCode": "Erfordere den super-sicheren Rettungscode zur späteren Backup-Entschüsselung für maximale Sicherheit." }
   ]
 }

--- a/SQRLDotNetClientUI/Models/PdfHelper.cs
+++ b/SQRLDotNetClientUI/Models/PdfHelper.cs
@@ -127,7 +127,7 @@ namespace SQRLDotNetClientUI.Models
             string qrCodeMessage = _loc.GetLocalizationValue("IdentityDocumentQRCodeMessage");
             string textualIdentityMessage = _loc.GetLocalizationValue("IdentityDocumentTextualIdentityMessage");
             string guidanceMessage = _loc.GetLocalizationValue("IdentityDocumentGuidanceMessage");
-            var identityBytes = identity.ToByteArray(includeHeader: true, minimumSize: true);
+            var identityBytes = identity.ToByteArray(includeHeader: true, new List<ushort>() { 2, 3 });
             string textualIdentity = SQRL.GenerateTextualIdentityBase56(identityBytes);
 
             var metadata = new SKDocumentPdfMetadata

--- a/SQRLDotNetClientUI/Models/PdfHelper.cs
+++ b/SQRLDotNetClientUI/Models/PdfHelper.cs
@@ -114,7 +114,8 @@ namespace SQRLDotNetClientUI.Models
         /// </summary>
         /// <param name="fileName">The full file name (including the path) for the document.</param>
         /// <param name="identity">The identity for which to create the document.</param>
-        public static void CreateIdentityDocument(string fileName, SQRLIdentity identity)
+        /// <param name="blockTypes">Spciefies a list of block types to include.</param>
+        public static void CreateIdentityDocument(string fileName, SQRLIdentity identity, List<ushort> blockTypes)
         {
             if (string.IsNullOrEmpty(fileName) || identity == null)
             {
@@ -127,7 +128,7 @@ namespace SQRLDotNetClientUI.Models
             string qrCodeMessage = _loc.GetLocalizationValue("IdentityDocumentQRCodeMessage");
             string textualIdentityMessage = _loc.GetLocalizationValue("IdentityDocumentTextualIdentityMessage");
             string guidanceMessage = _loc.GetLocalizationValue("IdentityDocumentGuidanceMessage");
-            var identityBytes = identity.ToByteArray(includeHeader: true, new List<ushort>() { 2, 3 });
+            var identityBytes = identity.ToByteArray(includeHeader: true, blockTypes);
             string textualIdentity = SQRL.GenerateTextualIdentityBase56(identityBytes);
 
             var metadata = new SKDocumentPdfMetadata

--- a/SQRLDotNetClientUI/Models/PdfHelper.cs
+++ b/SQRLDotNetClientUI/Models/PdfHelper.cs
@@ -175,7 +175,7 @@ namespace SQRLDotNetClientUI.Models
         private static SKBitmap CreateQRCode(byte[] identityBytes)
         {
             QRCodeGenerator qrGenerator = new QRCodeGenerator();
-            QRCodeData qrCodeData = qrGenerator.CreateQrCode(identityBytes, QRCodeGenerator.ECCLevel.H);
+            QRCodeData qrCodeData = qrGenerator.CreateQrCode(identityBytes, QRCodeGenerator.ECCLevel.M);
             QRCode qrCode = new QRCode(qrCodeData);
             var bitmap = qrCode.GetGraphic(3, System.Drawing.Color.Black, System.Drawing.Color.White, true);
             using (var stream = new MemoryStream())

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -116,14 +116,16 @@ namespace SQRLDotNetClientUI.ViewModels
         /// </summary>
         public async void SaveToFile()
         {
-            SaveFileDialog ofd = new SaveFileDialog();
+            SaveFileDialog sfd = new SaveFileDialog();
 
-            ofd.Title = _loc.GetLocalizationValue("SaveIdentityDialogTitle");
-            ofd.InitialFileName = $"{(string.IsNullOrEmpty(this.Identity.IdentityName)?"Identity":this.Identity.IdentityName)}.sqrl";
-            var file = await ofd.ShowAsync(_mainWindow);
+            var fileExtension = this.ExportWithPassword ? "sqrl" : "sqrc";
+            sfd.Title = _loc.GetLocalizationValue("SaveIdentityDialogTitle");
+            sfd.InitialFileName = $"{(string.IsNullOrEmpty(this.Identity.IdentityName)?"Identity":this.Identity.IdentityName)}.{fileExtension}";
+            sfd.DefaultExtension = fileExtension;
+            var file = await sfd.ShowAsync(_mainWindow);
             if(!string.IsNullOrEmpty(file))
             {
-                this.Identity.WriteToFile(file);
+                this.Identity.WriteToFile(file, skipBlockType1: !this.ExportWithPassword);
                 
                 await new MessageBoxViewModel(_loc.GetLocalizationValue("IdentityExportedMessageBoxTitle"),
                     string.Format(_loc.GetLocalizationValue("IdentityExportedMessageBoxText"), file),

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -20,6 +20,8 @@ namespace SQRLDotNetClientUI.ViewModels
     public class ExportIdentityViewModel: ViewModelBase
     {
         private Avalonia.Media.Imaging.Bitmap _qrImage;
+        private bool _exportWithPassword = false;
+        private bool _showQrCode = false;
 
         /// <summary>
         /// Gets or sets a bitmap representing the identity as a QR-code.
@@ -34,6 +36,28 @@ namespace SQRLDotNetClientUI.ViewModels
         /// The currently active identity.
         /// </summary>
         public SQRLIdentity Identity { get; }
+
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the exported identity
+        /// can be decrypted with either the password and the rescue code
+        /// or with the rescue code only.
+        /// </summary>
+        public bool ExportWithPassword 
+        {
+            get { return _exportWithPassword; }
+            set { this.RaiseAndSetIfChanged(ref _exportWithPassword, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether or not to display the
+        /// identity qr-code in the UI.
+        /// </summary>
+        public bool ShowQrCode
+        {
+            get { return _showQrCode; }
+            set { this.RaiseAndSetIfChanged(ref _showQrCode, value); }
+        }
 
         /// <summary>
         /// Creates a new instance and initializes.
@@ -131,6 +155,16 @@ namespace SQRLDotNetClientUI.ViewModels
                     MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.OK)
                     .ShowDialog(this);
             }
+        }
+
+        /// <summary>
+        /// Toggles the visibility of the qr code UI.
+        /// </summary>
+        /// <param name="visible">Set to <c>true</c> to show the qr code, 
+        /// or <c>false</c> to hide it</param>
+        public void ToggleQrCode(bool visible)
+        {
+            this.ShowQrCode = visible;
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -1,6 +1,5 @@
 ﻿using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Platform;
 using QRCoder;
 using ReactiveUI;
 using SQRLDotNetClientUI.Models;
@@ -20,7 +19,7 @@ namespace SQRLDotNetClientUI.ViewModels
     public class ExportIdentityViewModel: ViewModelBase
     {
         private Avalonia.Media.Imaging.Bitmap _qrImage;
-        private bool _exportWithPassword = false;
+        private bool _exportWithPassword = true;
         private bool _showQrCode = false;
 
         /// <summary>
@@ -98,7 +97,7 @@ namespace SQRLDotNetClientUI.ViewModels
         {
             var identityBytes = this.Identity.ToByteArray(includeHeader: true, _blocksToExport);
             QRCodeGenerator qrGenerator = new QRCodeGenerator();
-            QRCodeData qrCodeData = qrGenerator.CreateQrCode(identityBytes, QRCodeGenerator.ECCLevel.Q);
+            QRCodeData qrCodeData = qrGenerator.CreateQrCode(identityBytes, QRCodeGenerator.ECCLevel.M);
             QRCode qrCode = new QRCode(qrCodeData);
 
             var qrCodeBitmap = qrCode.GetGraphic(3, System.Drawing.Color.Black, System.Drawing.Color.White, true);
@@ -171,7 +170,7 @@ namespace SQRLDotNetClientUI.ViewModels
 
             try
             {
-                PdfHelper.CreateIdentityDocument(file, this.Identity); 
+                PdfHelper.CreateIdentityDocument(file, this.Identity, _blocksToExport); 
                 ProcessStartInfo psi = new ProcessStartInfo
                 {
                     FileName = file,

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -68,7 +68,7 @@ namespace SQRLDotNetClientUI.ViewModels
             this.Title = _loc.GetLocalizationValue("ExportIdentityWindowTitle");
             this.Identity = _identityManager.CurrentIdentity;
 
-            var textualIdentityBytes = this.Identity.ToByteArray(includeHeader: true, minimumSize: true);
+            var textualIdentityBytes = this.Identity.ToByteArray(includeHeader: true, new List<ushort>() { 2, 3 });
             QRCodeGenerator qrGenerator = new QRCodeGenerator();
             QRCodeData qrCodeData = qrGenerator.CreateQrCode(textualIdentityBytes, QRCodeGenerator.ECCLevel.H);
             QRCode qrCode = new QRCode(qrCodeData);
@@ -109,7 +109,7 @@ namespace SQRLDotNetClientUI.ViewModels
         /// </summary>
         public async void CopyToClipboard()
         {
-            var textualIdentityBytes = this.Identity.ToByteArray(includeHeader: true, minimumSize: true);
+            var textualIdentityBytes = this.Identity.ToByteArray(includeHeader: true, new List<ushort>() { 2, 3 });
 
             string identity = SQRL.GenerateTextualIdentityBase56(textualIdentityBytes);
             await Application.Current.Clipboard.SetTextAsync(identity);

--- a/SQRLDotNetClientUI/Views/ExportIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/ExportIdentityView.xaml
@@ -10,11 +10,35 @@
   <DockPanel LastChildFill="False" Margin="20,10,20,20">
     
     <StackPanel DockPanel.Dock="Top">
-      <TextBlock Text="{loc:Localization ExportIdentityMessage}" Margin="0,0,0,5" FontSize="12" TextWrapping="Wrap" />
-      <Image Source="{Binding QRImage}" Stretch="Uniform" Margin="0,0,0,5" Width="200" Height="200" HorizontalAlignment="Center"/>
-      <Button Content="{loc:Localization BtnSaveToFile}" Margin="0,0,0,10" Command="{Binding SaveToFile}" Width="220" HorizontalAlignment="Center" />
-      <Button Content="{loc:Localization BtnCopyToClipboard}" Margin="0,0,0,10" Command="{Binding CopyToClipboard}" Width="220" HorizontalAlignment="Center" />
-      <Button Content="{loc:Localization BtnSaveAsPdf}" Margin="0,0,0,10" Command="{Binding SaveAsPdf}" Width="220" HorizontalAlignment="Center" />
+      
+      <TextBlock Text="{loc:Localization ExportIdentityMessage}" Margin="0,0,0,15" FontSize="12" TextWrapping="Wrap" />
+      
+      <StackPanel IsVisible="{Binding ShowQrCode}">
+        <Image Source="{Binding QRImage}" Stretch="Uniform" Margin="0,0,0,5" Width="200" Height="200" HorizontalAlignment="Center"/>
+        <Button Content="{loc:Localization BtnBack}" Margin="0,0,0,10" Command="{Binding ToggleQrCode}" CommandParameter="False" Width="220" HorizontalAlignment="Center" />
+      </StackPanel>
+      
+      <StackPanel IsVisible="{Binding !ShowQrCode}">
+        <Border Margin="0,0,0,20" BorderBrush="LightGray" BorderThickness="1" CornerRadius="4">
+          <StackPanel Margin="20">
+            <RadioButton IsChecked="{Binding ExportWithPassword}" Margin="0,0,0,10">
+              <RadioButton.Content>
+                <TextBlock Text="{loc:Localization RadButExortWithPassword}" TextWrapping="Wrap" Margin="10,0,0,0" />
+              </RadioButton.Content>
+            </RadioButton>
+            <RadioButton  IsChecked="{Binding !ExportWithPassword}">
+              <RadioButton.Content>
+                <TextBlock Text="{loc:Localization RadButExortWithRescueCode}" TextWrapping="Wrap" Margin="10,0,0,0"/>
+              </RadioButton.Content>
+            </RadioButton>
+          </StackPanel>
+        </Border>
+        <Button Content="{loc:Localization BtnShowQrCode}" Command="{Binding ToggleQrCode}" CommandParameter="True" Margin="0,0,0,10" Width="220" HorizontalAlignment="Center" />
+        <Button Content="{loc:Localization BtnSaveToFile}" Command="{Binding SaveToFile}" Margin="0,0,0,10" Width="220" HorizontalAlignment="Center" />
+        <Button Content="{loc:Localization BtnCopyToClipboard}" Command="{Binding CopyToClipboard}" Margin="0,0,0,10" Width="220" HorizontalAlignment="Center" />
+        <Button Content="{loc:Localization BtnSaveAsPdf}" Command="{Binding SaveAsPdf}" Margin="0,0,0,10" Width="220" HorizontalAlignment="Center" />
+      </StackPanel>
+      
     </StackPanel>
 
     <StackPanel DockPanel.Dock="Bottom">

--- a/SQRLUtilsLib/SQRLIdentity.cs
+++ b/SQRLUtilsLib/SQRLIdentity.cs
@@ -124,9 +124,19 @@ namespace SQRLUtilsLib
         /// target file aleady exists, it is overwritten!
         /// </summary>
         /// <param name="fileName">The full file path of the identity file to be created.</param>
-        public void WriteToFile(string fileName)
+        /// <param name="skipBlockType1">If set to <c>true</c>, block type 1 will not be written
+        /// to the file, requiring the rescue code to decode the resulting identity file.</param>
+        public void WriteToFile(string fileName, bool skipBlockType1 = false)
         {
-            File.WriteAllBytes(fileName, this.ToByteArray());
+            List<ushort> blockTypes = new List<ushort>();
+
+            foreach (var block in Blocks)
+            {
+                if (block.Type == 1 && skipBlockType1) continue;
+                blockTypes.Add(block.Type);
+            }
+            
+            File.WriteAllBytes(fileName, this.ToByteArray(includeHeader: true, blockTypes));
         }
 
         /// <summary>

--- a/SQRLUtilsLib/SQRLIdentity.cs
+++ b/SQRLUtilsLib/SQRLIdentity.cs
@@ -93,24 +93,28 @@ namespace SQRLUtilsLib
         }
 
         /// <summary>
-        /// Returns the raw byte representation of the identity, optionally
-        /// including the plaintext "sqrldata" SQRL header.
+        /// Returns the raw byte representation of the identity. Optional parameters
+        /// specify whether to include the plaintext "sqrldata" header and which block 
+        /// types to include.
         /// </summary>
-        /// <param name="includeHeader">If set to true, the resulting byte array will include the 
-        /// plaintext "sqrldata" header</param>
-        /// <param name="minimumSize">If set to true, only block 2 (and block 3 if available)
-        /// will be included in the resulting byte array. Please note that decrypting the resulting
-        /// identity will require the secret rescue code.</param>
-        public byte[] ToByteArray(bool includeHeader = true, bool minimumSize = false)
+        /// <param name="includeHeader">If set to true, the resulting byte array will 
+        /// include the plaintext "sqrldata" header</param>
+        /// <param name="blockTypes">Spciefies a list of block types to include. If set to
+        /// <c>null</c>, all available block types will be included.</param>
+        public byte[] ToByteArray(bool includeHeader = true, List<ushort> blockTypes = null)
         {
-            byte[] data = includeHeader ? 
+            byte[] data = includeHeader ?
                 Encoding.UTF8.GetBytes(SQRLHEADER) : new byte[] { };
 
-            foreach (var block in Blocks)
+            var selectedBlocks = blockTypes == null ?
+                Blocks :
+                Blocks.Where(b => blockTypes.Contains(b.Type));
+
+            foreach (var block in selectedBlocks)
             {
-                if (minimumSize && block.Type != 2 && block.Type != 3) continue;
                 data = data.Concat(block.ToByteArray()).ToArray();
             }
+
             return data;
         }
 


### PR DESCRIPTION
Closes #116.

### Description:
This adds two options to the "Export Identity" screen:
- Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security.
- Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security.

Also, the QR code is now hidden by default and can be displayed by pressing a button. 
All the export methods now respect the decryption choices.

![export_new](https://user-images.githubusercontent.com/4005543/79908026-d83b4300-841a-11ea-8962-a96398d50d14.gif)
