### PR TITLE
Fixing macOS crash bugs

### DIFF
--- a/SQRLDotNetClientUI/App.xaml.cs
+++ b/SQRLDotNetClientUI/App.xaml.cs
@@ -13,16 +13,12 @@ using Avalonia.Controls;
 using System.Collections.Generic;
 using SQRLCommonUI.AvaloniaExtensions;
 using ReactiveUI;
-using SQRLUtilsLib;
 
 namespace SQRLDotNetClientUI
 {
     public class App : Application
     {
-        // We establish and keep a QuickPassManager instance here
-        // so that it will immediately receive system event notifications
-        private QuickPassManager _quickPassManager = QuickPassManager.Instance;
-
+        private QuickPassManager _quickPassManager = null;
         private ContextMenu _NotifyIconContextMenu = null;
         private MainWindow _mainWindow = null;
 
@@ -77,7 +73,6 @@ namespace SQRLDotNetClientUI
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-              
                 // If this is running on a Mac we need a special event handler for URL schema invokation
                 // This also handles System Events and notifications, it gives us a native foothold on a Mac.
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -128,13 +123,15 @@ namespace SQRLDotNetClientUI
                     NotifyIcon.Visible = true;
                 }
 
+                // We establish and keep a QuickPassManager instance here
+                // so that it will immediately receive system event notifications
+                _quickPassManager = QuickPassManager.Instance;
+
                 // Set up the app's main window, if we aren't staring minimized to tray
                 if (!AppSettings.Instance.StartMinimized || NotifyIcon == null)
                 {
                     desktop.MainWindow = _mainWindow;
-                }
-                
-                
+                }                
             }          
 
             base.OnFrameworkInitializationCompleted();

--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -161,7 +161,8 @@
     { "CPSAbortLinkText": "Go Back Now" },
     { "BtnShowQrCode": "Show QR Code" },
     { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
-    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." }
+    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
+    { "MissingLibGdiPlusErrorMessage":  "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nTaking you to the install instructions now..."}
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -325,7 +326,8 @@
     { "CPSAbortLinkText": "Go Back Now" },
     { "BtnShowQrCode": "Show QR Code" },
     { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
-    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." }
+    { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
+    { "MissingLibGdiPlusErrorMessage": "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nTaking you to the install instructions now..." }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -489,6 +491,7 @@
     { "CPSAbortLinkText": "Jetzt zurückgehen" },
     { "BtnShowQrCode": "QR-Code anzeigen" },
     { "RadButExortWithPassword": "Erlaube Backup-Entschlüsselung mit Passwort oder Rettungscode für mehr Bequemlichkeit aber leicht reduzierte Sicherheit." },
-    { "RadButExortWithRescueCode": "Erfordere den super-sicheren Rettungscode zur späteren Backup-Entschüsselung für maximale Sicherheit." }
+    { "RadButExortWithRescueCode": "Erfordere den super-sicheren Rettungscode zur späteren Backup-Entschüsselung für maximale Sicherheit." },
+    { "MissingLibGdiPlusErrorMessage": "Die wichtige Progrmmbibliothek \"libgdiplus\" fehlt. Einige Teile dieser App funktionieren nicht korrekt, solange diese Bibliothek nicht installiert ist.\r\n\r\nSie werden zur Seite mit der Installationsanleitung umgeleitet..." }
   ]
 }

--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -162,7 +162,7 @@
     { "BtnShowQrCode": "Show QR Code" },
     { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
     { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
-    { "MissingLibGdiPlusErrorMessage":  "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nTaking you to the install instructions now..."}
+    { "MissingLibGdiPlusErrorMessage":  "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nYou will find install instructions on the project's Github Wiki."}
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -327,7 +327,7 @@
     { "BtnShowQrCode": "Show QR Code" },
     { "RadButExortWithPassword": "Allow backup decryption with either the password or the rescue code for more convenience but somewhat reduced security." },
     { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
-    { "MissingLibGdiPlusErrorMessage": "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nTaking you to the install instructions now..." }
+    { "MissingLibGdiPlusErrorMessage": "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nYou will find install instructions on the project's Github Wiki." }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -492,6 +492,6 @@
     { "BtnShowQrCode": "QR-Code anzeigen" },
     { "RadButExortWithPassword": "Erlaube Backup-Entschlüsselung mit Passwort oder Rettungscode für mehr Bequemlichkeit aber leicht reduzierte Sicherheit." },
     { "RadButExortWithRescueCode": "Erfordere den super-sicheren Rettungscode zur späteren Backup-Entschüsselung für maximale Sicherheit." },
-    { "MissingLibGdiPlusErrorMessage": "Die wichtige Progrmmbibliothek \"libgdiplus\" fehlt. Einige Teile dieser App funktionieren nicht korrekt, solange diese Bibliothek nicht installiert ist.\r\n\r\nSie werden zur Seite mit der Installationsanleitung umgeleitet..." }
+    { "MissingLibGdiPlusErrorMessage": "Die wichtige Progrmmbibliothek \"libgdiplus\" fehlt. Einige Teile dieser App funktionieren nicht korrekt, solange diese Bibliothek nicht installiert ist.\r\n\r\nInstallationsanweisungen finden Sie im Projekt-Wiki auf Github." }
   ]
 }

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -198,9 +198,18 @@ namespace SQRLDotNetClientUI.ViewModels
                 };
                 Process.Start(psi);
             }
+            catch (TypeInitializationException ex)
+            {
+                Log.Error($"{ex.GetType().ToString()} was thrown while creating an identity pdf: {ex.Message}");
+
+                await new MessageBoxViewModel(_loc.GetLocalizationValue("ErrorTitleGeneric"),
+                    _loc.GetLocalizationValue("MissingLibGdiPlusErrorMessage"),
+                    MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
+                    .ShowDialog(this);
+            }
             catch (Exception ex) 
             {
-                Log.Error($"{ex.GetType().ToString()} was thrown while creating an identity pdf.");
+                Log.Error($"{ex.GetType().ToString()} was thrown while creating an identity pdf: {ex.Message}");
 
                 await new MessageBoxViewModel(_loc.GetLocalizationValue("ErrorTitleGeneric"), ex.Message,
                     MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.ERROR)

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -200,8 +200,10 @@ namespace SQRLDotNetClientUI.ViewModels
             }
             catch (Exception ex) 
             {
+                Log.Error($"{ex.GetType().ToString()} was thrown while creating an identity pdf.");
+
                 await new MessageBoxViewModel(_loc.GetLocalizationValue("ErrorTitleGeneric"), ex.Message,
-                    MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.OK)
+                    MessageBoxSize.Small, MessageBoxButtons.OK, MessageBoxIcons.ERROR)
                     .ShowDialog(this);
             }
         }

--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -96,6 +96,12 @@ namespace SQRLDotNetClientUI.ViewModels
         /// </summary>
         private async void UpdateQrCode()
         {
+            // If ExportIdentityView is not yet fully loaded, we need to drop out
+            // because if a message box gets shown in this state, it will mess up 
+            // our "content/previous content" system.
+            if (((MainWindowViewModel)_mainWindow.DataContext).Content.GetType() != typeof(ExportIdentityViewModel))
+                return;
+
             var identityBytes = this.Identity.ToByteArray(includeHeader: true, _blocksToExport);
 
             try
@@ -207,6 +213,7 @@ namespace SQRLDotNetClientUI.ViewModels
         /// or <c>false</c> to hide it</param>
         public void ToggleQrCode(bool visible)
         {
+            UpdateQrCode();
             this.ShowQrCode = visible;
         }
 


### PR DESCRIPTION
Fixes #110.

### Description:
This fixes some macOS related crash bugs:

- Regression that was introduced lately that would cause the app to crash on startup on macOS (`NSApplication.Init()` issue).
- Handles the case when `libgdiplus` is missing more gracefully than before:

![libgdiplus_fix](https://user-images.githubusercontent.com/4005543/80248645-a7ece200-8670-11ea-878b-2537d1339906.gif)
