### PR TITLE
Fixes Mac Console / Delegate Glitch

### DIFF
--- a/.github/PublishAllPlatforms.ps1
+++ b/.github/PublishAllPlatforms.ps1
@@ -59,8 +59,8 @@ Compress-Archive -Path "..\SQRLDotNetClientUI\bin\Release\netcoreapp3.1\win-x64\
 
 
 #Copying Platform Aware Installer (binary) to Publishing Folder
-Copy-Item ".\bin\Release\netcoreapp3.1\osx-x64\publish\SQRLPlatformAwareInstaller_osx" -Destination "C:\Temp\SQRL\Publish\" -Force
-Copy-Item ".\bin\Release\netcoreapp3.1\linux-x64\publish\SQRLPlatformAwareInstaller_linux" -Destination "C:\Temp\SQRL\Publish\" -Force
+tar -cvzf C:\Temp\SQRL\Publish\SQRLPlatformAwareInstaller_osx.tar.gz -C .\bin\Release\netcoreapp3.1\osx-x64\publish\ ./SQRLPlatformAwareInstaller_osx
+tar -cvzf C:\Temp\SQRL\Publish\SQRLPlatformAwareInstaller_linux.tar.gz -C .\bin\Release\netcoreapp3.1\linux-x64\publish\ ./SQRLPlatformAwareInstaller_linux
 Copy-Item ".\bin\Release\netcoreapp3.1\win-x64\publish\SQRLPlatformAwareInstaller_win.exe" -Destination "C:\Temp\SQRL\Publish\" -Force
 
 echo "Creating Github Release for Milestone: $milestone"
@@ -95,7 +95,7 @@ $jsonObject = ConvertFrom-Json $([String]::new($newRelease.Content))
 Get-ChildItem "C:\Temp\SQRL\Publish"| 
 #For each file in the publishing folder upload the asset
 Foreach-Object {
-    $contentType = If ($_.Extension -eq ".zip") {"application/x-zip-compressed"} else {"application/octet-stream"}
+    $contentType = If ($_.Extension -eq ".zip") {"application/application/x-gzip"} If ($_.Extension -eq ".gz") {"application/x-gzip"} else {"application/octet-stream"}
     $fileHeaders = @{
         "Accept"="application/vnd.github.v3+json"
         "Authorization"="token $token"

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
@@ -124,9 +124,24 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         }
 
+        public override void WillFinishLaunching(NSNotification notification)
+        {
+            base.WillFinishLaunching(notification);
+            if(NSApplication.SharedApplication.ActivationPolicy != NSApplicationActivationPolicy.Regular)
+            {
+                foreach(var x in NSRunningApplication.GetRunningApplications(@"com.apple.dock"))
+                {
+                    x.Activate(NSApplicationActivationOptions.ActivateIgnoringOtherWindows);
+                    break;
+                }
+                NSApplication.SharedApplication.ActivationPolicy = NSApplicationActivationPolicy.Regular;
+            }
+        }
+
         public override void DidFinishLaunching(NSNotification notification)
         {
-            IsFinishedLaunching = true;
+            base.DidFinishLaunching(notification);
+            NSRunningApplication.CurrentApplication.Activate(NSApplicationActivationOptions.ActivateIgnoringOtherWindows);
         }
 
 

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
@@ -124,9 +124,16 @@ namespace SQRLDotNetClientUI.Platform.OSX
 
         }
 
+        /// <summary>
+        /// Because we are creating our own mac application delegate we are removing / overriding 
+        /// the one that Avalonia creates. This causes the application to not be handled as it should.
+        /// This is the Avalonia Implementation: https://github.com/AvaloniaUI/Avalonia/blob/5a2ef35dacbce0438b66d9f012e5f629045beb3d/native/Avalonia.Native/src/OSX/app.mm
+        /// So what we are doing here is re-creating this implementation to mimick their behavior.
+        /// </summary>
+        /// <param name="notification"></param>
         public override void WillFinishLaunching(NSNotification notification)
         {
-            base.WillFinishLaunching(notification);
+            
             if(NSApplication.SharedApplication.ActivationPolicy != NSApplicationActivationPolicy.Regular)
             {
                 foreach(var x in NSRunningApplication.GetRunningApplications(@"com.apple.dock"))
@@ -138,9 +145,16 @@ namespace SQRLDotNetClientUI.Platform.OSX
             }
         }
 
+        /// <summary>
+        /// Because we are creating our own mac application delegate we are removing / overriding 
+        /// the one that Avalonia creates. This causes the application to not be handled as it should.
+        /// This is the Avalonia Implementation: https://github.com/AvaloniaUI/Avalonia/blob/5a2ef35dacbce0438b66d9f012e5f629045beb3d/native/Avalonia.Native/src/OSX/app.mm
+        /// So what we are doing here is re-creating this implementation to mimick their behavior.
+        /// </summary>
+        /// <param name="notification"></param>
         public override void DidFinishLaunching(NSNotification notification)
         {
-            base.DidFinishLaunching(notification);
+            
             NSRunningApplication.CurrentApplication.Activate(NSApplicationActivationOptions.ActivateIgnoringOtherWindows);
         }
 

--- a/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
+++ b/SQRLDotNetClientUI/Platform/OSX/AppDelegate.cs
@@ -116,7 +116,6 @@ namespace SQRLDotNetClientUI.Platform.OSX
                                 (Application.Current as App).RestoreMainWindow();
                             });
                         }
-
                     }
 
                 }


### PR DESCRIPTION
So Avalonia registers their own App Delegate on MacOSX 
See: https://github.com/AvaloniaUI/Avalonia/blob/5a2ef35dacbce0438b66d9f012e5f629045beb3d/native/Avalonia.Native/src/OSX/app.mm#L7-L23

In our application we register our own which cases Avalonia's to get removed https://github.com/sqrldev/SQRLDotNetClient/blob/b2463a079559d7a56d73821697c412d2eb4f2b93/SQRLDotNetClientUI/App.xaml.cs#L82

This causes the Avalonia registered events 
```
- (void)applicationWillFinishLaunching:(NSNotification *)notification
{
    if([[NSApplication sharedApplication] activationPolicy] != AvnDesiredActivationPolicy)
    {
        for (NSRunningApplication * app in [NSRunningApplication runningApplicationsWithBundleIdentifier:@"com.apple.dock"]) {
            [app activateWithOptions:NSApplicationActivateIgnoringOtherApps];
            break;
        }
        
        [[NSApplication sharedApplication] setActivationPolicy: AvnDesiredActivationPolicy];
    }
}


- (void)applicationDidFinishLaunching:(NSNotification *)notification
{
    [[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
}
```

To no be executed which causes our application to not be activated with the right options.

This fix basically  re-implements the Avalonia events in our own AppDelegate (I just re-wrote their code in C# inside our app delegate)

This appears to fix the issue and may prevent other issues we aren't yet aware of.

I also opened this Issue with Avalonia: https://github.com/AvaloniaUI/Avalonia/issues/3822 as an enhancement request.

It would be nice to be able to subscribe to all these events directly without having to re-implement the AppDelegate completely seeing as if they (Avalonia) changes or updates their delegate code our app won't benefit from that with this solution.

Either way it appears to work fine now
![ConsoleFix](https://user-images.githubusercontent.com/420837/80266718-568e2400-866b-11ea-8207-211c4ac1d4a7.gif)


Also change the mac and linux installers to tar.gz #143 
