### PR TITLE
Expose installer version

### DIFF
--- a/SQRLPlatformAwareInstaller/Program.cs
+++ b/SQRLPlatformAwareInstaller/Program.cs
@@ -27,8 +27,11 @@ namespace SQRLPlatformAwareInstaller
                 .WriteTo.File(logFilePath, rollingInterval: RollingInterval.Day)
                 .CreateLogger();
 
-            Log.Information("New app instance is being launched on {OSDescription}",
+            Log.Information("New installer instance is being launched on {OSDescription}",
                 RuntimeInformation.OSDescription);
+
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            Log.Information($"Installer version: {version.ToString()}");
 
             BuildAvaloniaApp()
             .StartWithClassicDesktopLifetime(args);

--- a/SQRLPlatformAwareInstaller/ViewModels/MainInstallViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/MainInstallViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 using Avalonia.Media.Imaging;
 using ReactiveUI;
@@ -40,6 +41,18 @@ namespace SQRLPlatformAwareInstaller.ViewModels
                     return "Linux";
                 else
                     return "";
+            }
+        }
+
+        /// <summary>
+        /// Gets a string representing the installer version.
+        /// </summary>
+        public string Version
+        {
+            get
+            {
+                return Assembly.GetExecutingAssembly().GetName()
+                    .Version.ToString();
             }
         }
 

--- a/SQRLPlatformAwareInstaller/Views/MainInstallView.xaml
+++ b/SQRLPlatformAwareInstaller/Views/MainInstallView.xaml
@@ -18,9 +18,12 @@
       <RowDefinition Height="Auto"/>
       <RowDefinition Height="*"/>
     </Grid.RowDefinitions>
-    
-    <Image Margin="10" VerticalAlignment="Top" Grid.Row="0" Grid.Column="0" Source="resm:SQRLPlatformAwareInstaller.Assets.SQRL_icon_normal_32.png" 
+
+    <DockPanel Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2">
+      <Image DockPanel.Dock="Left" Margin="10" VerticalAlignment="Top" Source="resm:SQRLPlatformAwareInstaller.Assets.SQRL_icon_normal_32.png"
            Stretch="None" HorizontalAlignment="Left"/>
+      <TextBlock Text="{Binding Version}" DockPanel.Dock="Right" Margin="10" HorizontalAlignment="Right" Foreground="LightGray" FontSize="10" />
+    </DockPanel>
     
     <TextBlock Text="{loc:Localization InstallerGreeting}" Grid.ColumnSpan="2" TextWrapping="Wrap" Margin="10" VerticalAlignment="Top" Grid.Row="1" Grid.Column="0" />
     <TextBlock Text="{loc:Localization DetectedPlatform}" Grid.Column="0" Margin="10" FontWeight="Bold" Grid.Row="2" VerticalAlignment="Center" />


### PR DESCRIPTION
Closes #154.

### Description: 
This exposes the installer version in two ways:
- Writes the version information into the log file on startup
- Displays the version information in the right upper corner of the initial installer screen