### PR TITLE
Fix installer blindly appending SQRL to install path

### DIFF
--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -178,7 +178,8 @@ namespace SQRLPlatformAwareInstaller.ViewModels
                     }
                 }
             }
-            this.InstallationPath = Environment.GetCommandLineArgs().Length > 1 ? Environment.GetCommandLineArgs()[1] : this.InstallationPath;
+            this.InstallationPath = Environment.GetCommandLineArgs().Length > 1 ? 
+                Environment.GetCommandLineArgs()[1] : this.InstallationPath;
         }
 
         /// <summary>
@@ -488,7 +489,15 @@ namespace SQRLPlatformAwareInstaller.ViewModels
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                         this.InstallationPath = Path.Combine(result);
                     else
-                        this.InstallationPath = Path.Combine(result, "SQRL");
+                    {
+                        var lastDir = Path.GetFileName(result.TrimEnd(Path.DirectorySeparatorChar));
+                        if (lastDir != "SQRL")
+                        {
+                            result = Path.Combine(result, "SQRL");
+                        }
+
+                        this.InstallationPath = result;
+                    }
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
Addresses the second part of #155.

### Description: 
Fix installer by checking if the selected install path already ends in "SQRL" before blindly appending it.