### PR TITLE
Remember install path

### DIFF
--- a/SQRLCommonUI/Models/PathConf.cs
+++ b/SQRLCommonUI/Models/PathConf.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
 
@@ -24,8 +25,11 @@ namespace SQRLCommonUI.Models
         /// <summary>
         /// The default client installation directory.
         /// </summary>
-        public static readonly string DefaultClientInstallPath = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "SQRL");
+        public static readonly string DefaultClientInstallPath = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "SQRL") :
+            RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)) :
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "SQRL");
 
         /// <summary>
         /// The default client database directory.

--- a/SQRLCommonUI/Models/PathConf.cs
+++ b/SQRLCommonUI/Models/PathConf.cs
@@ -19,7 +19,7 @@ namespace SQRLCommonUI.Models
         /// The full file path of the config file.
         /// </summary>
         public static readonly string ConfFile = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create),
             "SQRL", "sqrl.conf");
 
         /// <summary>

--- a/SQRLCommonUI/Models/PathConf.cs
+++ b/SQRLCommonUI/Models/PathConf.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+
+namespace SQRLCommonUI.Models
+{
+    /// <summary>
+    /// A helper class for reading and writing the config file
+    /// that specifies app installation and database paths.
+    /// </summary>
+    public static class PathConf
+    {
+        private static PathConfModel _model = new PathConfModel();
+
+        /// <summary>
+        /// The full file path of the config file.
+        /// </summary>
+        public static readonly string ConfFile = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "SQRL", "sqrl.conf");
+
+        /// <summary>
+        /// The default client installation directory.
+        /// </summary>
+        public static readonly string DefaultClientInstallPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "SQRL");
+
+        /// <summary>
+        /// The default client database directory.
+        /// </summary>
+        public static readonly string DefaultClientDBPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "SQRL");
+
+        /// <summary>
+        /// Gets or sets the SQRL client installation directory path.
+        /// </summary>
+        public static string ClientInstallPath
+        {
+            get
+            {
+                LoadConfig();
+                return _model.ClientInstallPath;
+            }
+            set
+            {
+                _model.ClientInstallPath = value;
+                SaveConfig();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the SQRL client's database directory path.
+        /// </summary>
+        public static string ClientDBPath
+        {
+            get
+            {
+                LoadConfig();
+                return _model.ClientDBPath;
+            }
+            set
+            {
+                _model.ClientDBPath = value;
+                SaveConfig();
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the path config file exists or not.
+        /// </summary>
+        public static bool ConfigFileExists
+        {
+            get { return File.Exists(ConfFile); }
+        }
+
+        /// <summary>
+        /// Reads all values from the config file. If the config file does not
+        /// exist, all config properties will have their default value.
+        /// </summary>
+        public static void LoadConfig()
+        {
+            if (!File.Exists(ConfFile))
+            {
+                // In no config file exists, "loading" shall reset the config to 
+                // default values. We achieve this by simply creating a new model.
+                _model = new PathConfModel();
+            }
+            else
+            {
+                _model = JsonSerializer.Deserialize<PathConfModel>(File.ReadAllText(ConfFile));
+            }
+        }
+
+        /// <summary>
+        /// Writes all values to the config file. If the config file does not 
+        /// exist, it gets created, along with all the directories involved.
+        /// An existing file will get overwritten.
+        /// </summary>
+        public static void SaveConfig()
+        {
+            var options = new JsonSerializerOptions
+            {
+                WriteIndented = true
+            };
+
+            if (_model == null) _model = new PathConfModel();
+            Directory.CreateDirectory(Path.GetDirectoryName(ConfFile));
+            string serialized = JsonSerializer.Serialize(_model, _model.GetType(), options);
+            File.WriteAllText(ConfFile, serialized);
+        }
+    }
+
+    /// <summary>
+    /// A class representing config entries used for 
+    /// serializing to / deserializing from a json file.
+    /// </summary>
+    public class PathConfModel
+    {
+        /// <summary>
+        /// The installation directory of the SQRL client.
+        /// </summary>
+        public string ClientInstallPath { get; set; } = PathConf.DefaultClientInstallPath;
+
+        /// <summary>
+        /// The directory where the SQRL client's database is located.
+        /// </summary>
+        public string ClientDBPath { get; set; } = PathConf.DefaultClientDBPath;
+    }
+}


### PR DESCRIPTION
Fixes #155.

### Description:
This stores the client installation path as well as the database path in a configuration file which gets placed in a well-defined and standards-compliant (XDG-spec) location on all 3 platforms:

```C#
public static readonly string ConfFile = Path.Combine(
    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData,
    Environment.SpecialFolderOption.Create), "SQRL", "sqrl.conf");
```
which results in these paths per platform:

- Windows: `C:\Users\$USER\AppData\Roaming\SQRL\sqrl.conf`
- Linux: `/home/$USER/.config/SQRL/sqrl.conf`
- macOS: `/Users/$USER/.config/SQRL/sqrl.conf`

### Implementation:
All functionality around reading/writing the config file is abstracted away using the new `PathConf` static class which resides in the `SQRLCommonUI` project so that both the client and installer can make use of it.

Getting or setting path values in the config file is done by using the class' public properties:

```C#
// Where was the client installed to?
var installPath = PathConf.ClientInstallPath;

// This will set a new install path (and write it to the config file)
PathConf.ClientInstallPath = @"C:\Test";
```

### Notes:

Functionality for remembering the client's database path is already present within `PathConf` but not yet implemented in the client/installer. This shall be done in a separate PR.