### PR TITLE
On Linux, only use a tray icon on Ubuntu

### DIFF
--- a/SQRLDotNetClientUI/Platform/Implementation.cs
+++ b/SQRLDotNetClientUI/Platform/Implementation.cs
@@ -34,7 +34,7 @@ namespace SQRLDotNetClientUI.Platform
                 {
                     // On Linux, we only support a tray icon for Ubuntu,
                     // sorry folks ¯\_(ツ)_/¯
-                    var response = _shell.Term($"cat /etc/*-release", Output.Internal);
+                    var response = _shell.Term($"cat /etc/*-release", Output.Hidden);
                     Log.Information($"Checking Linux distribution to see if we can use a tray icon");
                     Log.Information($"Output of \"cat / etc/*-release\" is:\r\n{response.stdout}");
                     if (!string.IsNullOrEmpty(response.stdout) && 

--- a/SQRLDotNetClientUI/Platform/Implementation.cs
+++ b/SQRLDotNetClientUI/Platform/Implementation.cs
@@ -1,4 +1,5 @@
-﻿using SQRLDotNetClientUI.Models;
+﻿using Serilog;
+using SQRLDotNetClientUI.Models;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -34,6 +35,8 @@ namespace SQRLDotNetClientUI.Platform
                     // On Linux, we only support a tray icon for Ubuntu,
                     // sorry folks ¯\_(ツ)_/¯
                     var response = _shell.Term($"cat /etc/*-release", Output.Internal);
+                    Log.Information($"Checking Linux distribution to see if we can use a tray icon");
+                    Log.Information($"Output of \"cat / etc/*-release\" is:\r\n{response.stdout}");
                     if (!string.IsNullOrEmpty(response.stdout) && 
                         response.stdout.ToLower().Contains("ubuntu"))
                     {


### PR DESCRIPTION
Closes #161.

### Description:
This restricts the use of the tray icon to Ubuntu on Linux. For other Linux distros, the app will be minimized to the dock instead of the tray.

### Implementation:
A `cat /etc/*-release` shell command will be issued on Linux, and if the resulting information contains the word `Ubuntu`, we're golden. Not a work of art, but it should do the job.