### PR TITLE
Add logging to Library

### DIFF
--- a/SQRLDotNetClientUI/Program.cs
+++ b/SQRLDotNetClientUI/Program.cs
@@ -82,16 +82,10 @@ namespace SQRLDotNetClientUI
                 }
                 finally
                 {
-                    Log.Information("App shutting down");
-
                     if (hasHandle)
                     {
                         mutex.ReleaseMutex();
                     }
-
-                    HandleAbruptCPS();
-
-
 
                     //Remove the notify icon
                     (App.Current as App).NotifyIcon?.Remove();
@@ -107,27 +101,26 @@ namespace SQRLDotNetClientUI
             }
         }
 
-
         /// <summary>
-        /// Try to capture abrupt process exit to gracefully handle CPS
+        /// Try to capture abrupt process exit to gracefully end any pending CPS requests.
         /// </summary>
-        /// <param name="sender"></param>
-        /// <param name="e"></param>
         private static void CurrentDomain_ProcessExit(object sender, EventArgs e)
         {
-            // One of the last ditch efforts at gracefully handling CPS, note there may be no localization here we are at this point throwing a hail marry
+            // One of the last ditch efforts at gracefully handling CPS, note there may be no 
+            // localization here we are at this point throwing a hail mary
             HandleAbruptCPS();
 
+            Log.Information("Client shutting down\r\n\r\n");
         }
 
         /// <summary>
-        /// Handles unclean process exit tries to save CPS
+        /// Handles pending CPS requests to end CPS gracefully.
         /// </summary>
         private static void HandleAbruptCPS()
         {
             try
             {
-                Log.Information("Attempting to End CPS Gracefully from Process Exit Event");
+                Log.Information("Attempting to end CPS gracefully");
                 var _loc = (App.Current as App)?.Localization;
                 if (_loc != null)
                 {
@@ -140,7 +133,7 @@ namespace SQRLDotNetClientUI
             }
             catch (Exception ex)
             {
-                Log.Error("Failed to Cancel CPS Gracefully", ex);
+                Log.Error("Failed to cancel CPS gracefully", ex);
             }
         }
 

--- a/SQRLDotNetClientUI/Program.cs
+++ b/SQRLDotNetClientUI/Program.cs
@@ -39,6 +39,9 @@ namespace SQRLDotNetClientUI
             Log.Information("New app instance is being launched on {OSDescription}", 
                 RuntimeInformation.OSDescription);
 
+            var version = Assembly.GetExecutingAssembly().GetName().Version;
+            Log.Information($"Client version: {version.ToString()}");
+
             // Try to detect an existing instance of our app
             using (var mutex = new Mutex(false, mutexId, out bool created))
             {

--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -228,7 +228,6 @@ namespace SQRLDotNetClientUI.ViewModels
         {
             _mainWindow.Close();
 
-            Log.Information("App shutting down");
             ((IClassicDesktopStyleApplicationLifetime)App.Current.ApplicationLifetime)
                 .Shutdown();
         }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -37,14 +37,19 @@ namespace SQRLUtilsLib
     {
         private static Lazy<SQRL> _instance = null;
         private static bool SodiumInitialized = false;
-
         private static readonly char[] BASE56_ALPHABETH = { '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
         private const int ENCODING_BASE = 56;
         private const int CLIENT_VERSION = 1;
 
-        
+        /// <summary>
+        /// Represents the "User-Agent" header that will be sent by all HTTP
+        /// queries performed by the library.
+        /// </summary>
+        public static string UserAgentHeader { get; set; } = "OSS SQRL Library for .NET Core";
 
-
+        /// <summary>
+        /// The server component handling the Client-Protected-Session (CPS).
+        /// </summary>
         public SQRLCPSServer cps=null;
 
         /// <summary>
@@ -1021,7 +1026,7 @@ namespace SQRLUtilsLib
             message = "";
             using (HttpClient wc = new HttpClient())
             {
-                wc.DefaultRequestHeaders.Add("User-Agent", "Jose Gomez SQRL Client");
+                wc.DefaultRequestHeaders.Add("User-Agent", UserAgentHeader);
                 if (opts == null)
                 {
                     opts = new string[]
@@ -1169,7 +1174,7 @@ namespace SQRLUtilsLib
             
             using (HttpClient wc = new HttpClient())
             {
-                wc.DefaultRequestHeaders.Add("User-Agent", "Jose Gomez SQRL Client");
+                wc.DefaultRequestHeaders.Add("User-Agent", UserAgentHeader);
 
                 StringBuilder client = new StringBuilder();
                 client.AppendLineWindows($"ver={CLIENT_VERSION}");
@@ -1215,7 +1220,7 @@ namespace SQRLUtilsLib
 
             using (HttpClient wc = new HttpClient())
             {
-                wc.DefaultRequestHeaders.Add("User-Agent", "Jose Gomez's SQRL Client");
+                wc.DefaultRequestHeaders.Add("User-Agent", UserAgentHeader);
 
                 StringBuilder client = new StringBuilder();
                 client.AppendLineWindows($"ver={CLIENT_VERSION}");
@@ -1387,7 +1392,7 @@ namespace SQRLUtilsLib
             }
             using (HttpClient wc = new HttpClient())
             {
-                wc.DefaultRequestHeaders.Add("User-Agent", "Jose Gomez's SQRL Client");
+                wc.DefaultRequestHeaders.Add("User-Agent", UserAgentHeader);
                 var content = new FormUrlEncodedContent(strContent);
                 var response = wc.PostAsync($"https://{sqrlUri.Host}{(sqrlUri.IsDefaultPort ? "" : $":{sqrlUri.Port}")}{sqrlUri.PathAndQuery}", content).Result;
                 var result = response.Content.ReadAsStringAsync().Result;

--- a/SQRLUtilsLib/SQRLIdentity.cs
+++ b/SQRLUtilsLib/SQRLIdentity.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -167,7 +168,10 @@ namespace SQRLUtilsLib
             {
                 string sqrlHeader = System.Text.Encoding.UTF8.GetString(identityData.Take(8).ToArray());
                 if (!sqrlHeader.Equals(SQRLHEADER, StringComparison.OrdinalIgnoreCase))
+                {
+                    Log.Error($"Error parsing identity from byte array: No SQRL header found!");
                     throw new IOException("Invalid File Exception, not a valid SQRL Identity File");
+                }
                 if (sqrlHeader.Equals(SQRLHEADER.ToUpper())) isBase64 = true;
             }
             else
@@ -294,12 +298,18 @@ namespace SQRLUtilsLib
         public void FromByteArray(byte[] blockData)
         {
             if (blockData.Length < 4)
+            {
+                Log.Error($"Error parsing block from byte array: Invalid block, incorrect number of bytes!");
                 throw new Exception("Invalid Block, incorrect number of bytes");
+            }
             this.Length = BitConverter.ToUInt16(blockData.Take(2).ToArray());
             this.Type = BitConverter.ToUInt16(blockData.Skip(2).Take(2).ToArray());
             
             if (blockData.Length < this.Length)
+            {
+                Log.Error($"Error parsing block from byte array: Invalid block length!");
                 throw new Exception("Invalid Block, incorrect number of bytes");
+            }
             this.BlockData = blockData.Skip(4).Take(this.Length-4).ToArray();
         }
 
@@ -311,7 +321,6 @@ namespace SQRLUtilsLib
             byteAry.AddRange(BlockData);
             return byteAry.ToArray();
         }
-
     }
 
     /// <summary>
@@ -341,7 +350,10 @@ namespace SQRLUtilsLib
         public void FromByteArray(byte[] blockData)
         {
             if (blockData.Length != 68)
+            {
+                Log.Error($"Error parsing block type 0 from byte array: Invalid block length!");
                 throw new Exception("Invalid Block 0, incorrect number of bytes");
+            }
             this.GenesisIdentifier = blockData.Skip(4).Take(32).ToArray();
             this.UniqueIdentifier = blockData.Skip(36).Take(32).ToArray();
         }
@@ -448,7 +460,10 @@ namespace SQRLUtilsLib
         public void FromByteArray(byte[] blockData)
         {
             if (blockData.Length != 125)
+            {
+                Log.Error($"Error parsing block type 1 from byte array: Invalid block length!");
                 throw new Exception("Invalid Block 1, incorrect number of bytes");
+            }
             this.AesGcmInitVector = blockData.Skip(6).Take(12).ToArray();
             this.ScryptRandomSalt = blockData.Skip(18).Take(16).ToArray();
             this.LogNFactor = blockData.Skip(34).Take(1).First();
@@ -528,7 +543,10 @@ namespace SQRLUtilsLib
         public void FromByteArray(byte[] blockData)
         {
             if (blockData.Length != 73)
+            {
+                Log.Error($"Error parsing block type 2 from byte array: Invalid block length!");
                 throw new Exception("Invalid Block 2, incorrect number of bytes");
+            }
             this.RandomSalt = blockData.Skip(4).Take(16).ToArray();
             this.LogNFactor = blockData.Skip(20).Take(1).First();
             this.IterationCount = BitConverter.ToUInt32(blockData.Skip(21).Take(4).ToArray());
@@ -591,7 +609,10 @@ namespace SQRLUtilsLib
         public void FromByteArray(byte[] blockData)
         {
             if (blockData.Length != 54 && blockData.Length != 86 && blockData.Length != 118 && blockData.Length != 150)
+            {
+                Log.Error($"Error parsing block type 3 from byte array: Invalid block length!");
                 throw new Exception("Invalid Block 3, incorrect number of bytes");
+            }
             this.Length = BitConverter.ToUInt16(blockData.Skip(0).Take(2).ToArray());
             this.Edition = BitConverter.ToUInt16(blockData.Skip(4).Take(2).ToArray());
             int skip = 6;

--- a/SQRLUtilsLib/SQRLUtilsLib.csproj
+++ b/SQRLUtilsLib/SQRLUtilsLib.csproj
@@ -35,6 +35,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Sodium.Core.ForSqrl" Version="1.2.2.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Closes #127.

### Description:
This adds basic logging to the library project. 

It basically only records library function calls as well as errors and exceptions at the moment, since we have to avoid logging any sensitive information. We can expand on the logging while we go along.

### Additional changes:
- Pull out `User-Agent` header into a public static property so that it can be changed by users of the library
- Change the the User-Agent to `"OSS SQRL Library for .NET Core"`
- Move the sodium initialization check into the `SodiumInit()` method instead of checking separately in each of the functions using it
- Some small improvements to the logging in the client
- Remove call to `HandleAbruptCPS()` from the `finally {}` block in Main, since it gets called again anyway in `CurrentDomain_ProcessExit`, which resulted in the method running twice.