### PR TITLE
Enable auth dialog to be triggered by either sqrl:// or CPS

### DIFF
--- a/SQRLDotNetClientUI/App.xaml.cs
+++ b/SQRLDotNetClientUI/App.xaml.cs
@@ -13,6 +13,13 @@ using Avalonia.Controls;
 using System.Collections.Generic;
 using SQRLCommonUI.AvaloniaExtensions;
 using ReactiveUI;
+using SQRLUtilsLib;
+using System.Threading;
+using System.Net;
+using Avalonia.Threading;
+using System.Text;
+using System.Web;
+using System.Linq;
 
 namespace SQRLDotNetClientUI
 {
@@ -21,6 +28,17 @@ namespace SQRLDotNetClientUI
         private QuickPassManager _quickPassManager = null;
         private ContextMenu _NotifyIconContextMenu = null;
         private MainWindow _mainWindow = null;
+        private readonly object _priorNutHashLockObject = new object();
+        private byte[] _priorNutHash = new byte[32];
+        private DateTime _lastNutHashUpdatedOn = DateTime.Now;
+
+        /// <summary>
+        /// The magic wakeup string is sent to an existing app instance
+        /// to signal that the existing instances main window should be shown.
+        /// This is only used if the new instance was started without any 
+        /// command line arguments.
+        /// </summary>
+        public static readonly string MagicWakeupString = "wakeup!";
 
         /// <summary>
         /// Defines the minimum time between two (automated) update checks.
@@ -49,6 +67,154 @@ namespace SQRLDotNetClientUI
         public App() : base()
         {
             this.Localization = new LocalizationExtension();
+            SQRL.StartCPSServer();
+            SQRL.CPS.CPSRequestReceived += CPSRequestReceived;
+        }
+
+        /// <summary>
+        /// Handles data coming in via Inter-Process-Communication.
+        /// </summary>
+        /// <param name="ipcDataString">The data received by the IPC server. This sould
+        /// either be a valid "sqrl://" URL to initiate an authentication operation, or 
+        /// the magic wakeup keyword if we only want to show the main window.</param>
+        public void HandleIPC(string ipcDataString)
+        {
+            if (ipcDataString == MagicWakeupString)
+            {
+                Log.Information("Showing main screen via IPC wakeup");
+                ShowMainScreen();
+            }
+            else
+            {
+                Log.Information("Try handling auth request via IPC");
+                HandleAuthRequest(ipcDataString, "IPC");
+            }
+        }
+
+        /// <summary>
+        /// This event handler gets called if the CPS server receives a new CPS request.
+        /// </summary>
+        private void CPSRequestReceived(object sender, CPSRequestReceivedEventArgs e)
+        {
+            // We're not interested in "gif" queries
+            if (e.Context.Request.RawUrl.EndsWith(".gif")) return;
+
+            // Extract and base64-decode the sqrl:// URL from the cps request
+            string data = e.Context.Request.Url.AbsolutePath.Substring(1);
+            string sqrlUrl = Encoding.UTF8.GetString(Sodium.Utilities.Base64ToBinary(
+                data, "", Sodium.Utilities.Base64Variant.UrlSafeNoPadding));
+
+            Log.Information("Try handling auth request via CPS");
+            HandleAuthRequest(sqrlUrl, "CPS");
+        }
+
+        /// <summary>
+        /// Checks if an auth request was already performed for the nut embedded within
+        /// <paramref name="sqrlUrl"/>, and if not, fires up the authentication screen.
+        /// Any auth request for a nut which was already handled will be ignored.
+        /// This handles the "race condition" that arises in our new approach where both
+        /// CPS and a sqrl:// scheme invocation can trigger an authentication popup.
+        /// </summary>
+        /// <param name="sqrlUrl">The "sqrl://" authentication URL.</param>
+        /// <param name="source">A string representing the caller of the method. Used for logging.</param>
+        private void HandleAuthRequest(string sqrlUrl, string source)
+        {
+            try
+            {
+                Uri uri = new Uri(sqrlUrl);
+                string nut = HttpUtility.ParseQueryString(uri.Query).Get("nut");
+                if (string.IsNullOrEmpty(nut)) return;
+
+                byte[] hashedNut = Sodium.CryptoHash.Sha256(nut);
+                bool isFirstAuthForThisNut = false;
+
+                Log.Information($"Locking last nut hash for {source} from Thread id {Thread.CurrentThread.ManagedThreadId}");
+                lock (this._priorNutHashLockObject)
+                {
+                    // First, let's check our timing:
+                    // If the last auth request using a fresh nut happend longer than 
+                    // 3 seconds ago, we can assume that the current request does not belong
+                    // to the same authentication event as that prior request, so we clear 
+                    // the "last nut" hash and start over fresh.
+                    // (We have to take into account that either of the two methods, CPS or
+                    // sqrl:// scheme invocation, could not be available, so clearing on the
+                    // second event with the same nut may not always happen!)
+                    TimeSpan timeSinceLastUpdate = _lastNutHashUpdatedOn - DateTime.Now;
+                    if (timeSinceLastUpdate.TotalSeconds > 3)
+                    {
+                        this._priorNutHash.ZeroFill();
+                    }
+
+                    // Now, let's check if the current request's hashed nut
+                    // matches the one from the last request
+                    if (!this._priorNutHash.SequenceEqual(hashedNut))
+                    {
+                        // Hashes do not match, so this is the first 
+                        // auth request for this nut. 
+                        this._priorNutHash = hashedNut;
+                        isFirstAuthForThisNut = true;
+                        _lastNutHashUpdatedOn = DateTime.Now;
+                    }
+                    else
+                    {
+                        // We've seen this hash before, so we're coming
+                        // in second. Let's clear our hash.
+                        this._priorNutHash.ZeroFill();
+                    }
+                }
+
+                if (isFirstAuthForThisNut)
+                {
+                    Log.Information($"Handling auth request via {source} succeeded, seems we came in first!");
+                    ShowAuthScreen(uri);
+                }
+                else
+                {
+                    Log.Information($"Handling auth request via {source} aborted, already handled by other source!");
+                }
+            }
+            catch (UriFormatException ufe)
+            {
+                Log.Error("Got CPS request with invalid URI!\r\n{UriFormatException}", ufe);
+            }
+            catch (Exception ex)
+            {
+                Log.Error("Error in CPSRequestReceived event handler:\r\n{Exception}", ex);
+            }
+        }
+
+        /// <summary>
+        /// Displays the app's authentication screen.
+        /// </summary>
+        /// <param name="uri"></param>
+        private void ShowAuthScreen(Uri uri)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                var mainMenuViewModel = ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
+
+                AuthenticationViewModel authView = new AuthenticationViewModel(uri);
+                mainMenuViewModel.AuthVM = authView;
+                ((MainWindowViewModel)_mainWindow.DataContext).Content = authView;
+
+                Log.Information("Showing auth screen!");
+
+                RestoreMainWindow();
+            });
+        }
+
+        /// <summary>
+        /// Displays the app's main screen.
+        /// </summary>
+        private void ShowMainScreen()
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                var mainMenuViewModel = ((MainWindowViewModel)_mainWindow.DataContext).MainMenu;
+                ((MainWindowViewModel)_mainWindow.DataContext).Content = mainMenuViewModel;
+
+                RestoreMainWindow();
+            });
         }
 
         /// <summary>

--- a/SQRLDotNetClientUI/Program.cs
+++ b/SQRLDotNetClientUI/Program.cs
@@ -56,7 +56,7 @@ namespace SQRLDotNetClientUI
                             // Existing instance detected, forward the first 
                             // command line argument if present.
                             Log.Information("Existing app instance detected, forwarding data and shutting down");
-                            ForwardToExistingInstance(args.Length > 0 ? args[0] : IPCServer.MAGIC_WAKEUP_STR);
+                            ForwardToExistingInstance(args.Length > 0 ? args[0] : App.MagicWakeupString);
                             Environment.Exit(1);
                         }
                     }
@@ -65,11 +65,8 @@ namespace SQRLDotNetClientUI
                         hasHandle = true;
                     }
 
-
                     // Adds event to handle abrupt program exits and mitigate CPS
                     AppDomain.CurrentDomain.ProcessExit += new EventHandler(CurrentDomain_ProcessExit);
-
-
 
                     // Perform database migrations
                     SQRLDBContext _db = new SQRLDBContext();

--- a/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/AuthenticationViewModel.cs
@@ -19,7 +19,6 @@ namespace SQRLDotNetClientUI.ViewModels
     /// </summary>
     public class AuthenticationViewModel : ViewModelBase
     {
-        private SQRL _sqrlInstance = SQRL.GetInstance(true);
         private QuickPassManager _quickPassManager = QuickPassManager.Instance;
         private bool _newUpdateAvailable = false;
         private LoginAction _action = LoginAction.Login;
@@ -453,17 +452,20 @@ namespace SQRLDotNetClientUI.ViewModels
                                 siteKvp, serverResponse.FullServerRequest, addClientData, sqrlOpts);
                             
                             SQRLCPSServer.HandlePendingCPS(_loc.GetLocalizationValue("CPSAbortHeader"), 
-                                                           _loc.GetLocalizationValue("CPSAbortMessage"), 
-                                                           _loc.GetLocalizationValue("CPSAbortLinkText"),new Uri(serverResponse.SuccessUrl));
+                                _loc.GetLocalizationValue("CPSAbortMessage"), 
+                                _loc.GetLocalizationValue("CPSAbortLinkText"),
+                                new Uri(serverResponse.SuccessUrl));
                             
                             ShowMainScreenAndClose();
                         }
                         break;
                     case LoginAction.Disable:
                         {
-                            var disableAccountAlert = string.Format(_loc.GetLocalizationValue("DisableAccountAlert"), this.SiteID, Environment.NewLine);
+                            var disableAccountAlert = string.Format(_loc.GetLocalizationValue("DisableAccountAlert"), 
+                                this.SiteID, Environment.NewLine);
                             
-                            var btResult = await new MessageBoxViewModel(_loc.GetLocalizationValue("WarningMessageBoxTitle").ToUpper(),
+                            var btResult = await new MessageBoxViewModel(
+                                _loc.GetLocalizationValue("WarningMessageBoxTitle").ToUpper(),
                                 disableAccountAlert, 
                                 MessageBoxSize.Large, MessageBoxButtons.YesNo, MessageBoxIcons.QUESTION)
                                 .ShowDialog(this);
@@ -474,9 +476,10 @@ namespace SQRLDotNetClientUI.ViewModels
                                 serverResponse = SQRL.GenerateSQRLCommand(SQRLCommands.disable, serverResponse.NewNutURL, 
                                     siteKvp, serverResponse.FullServerRequest, addClientData, sqrlOpts);
 
-                                SQRLCPSServer.HandlePendingCPS(_loc.GetLocalizationValue("CPSAbortHeader"), 
-                                                               _loc.GetLocalizationValue("CPSAbortMessage"), 
-                                                               _loc.GetLocalizationValue("CPSAbortLinkText"));
+                                SQRLCPSServer.HandlePendingCPS(_loc.GetLocalizationValue("CPSAbortHeader"),
+                                    _loc.GetLocalizationValue("CPSAbortMessage"), 
+                                    _loc.GetLocalizationValue("CPSAbortLinkText"));
+
                                 ShowMainScreenAndClose();
                             }
                         }

--- a/SQRLUtilsLib/SQRL.cs
+++ b/SQRLUtilsLib/SQRL.cs
@@ -36,7 +36,6 @@ namespace SQRLUtilsLib
     /// </remarks>
     public class SQRL
     {
-        private static Lazy<SQRL> _instance = null;
         private static bool SodiumInitialized = false;
         private static readonly char[] BASE56_ALPHABETH = { '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'K', 'L', 'M', 'N', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'm', 'n', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };
         private const int ENCODING_BASE = 56;
@@ -51,42 +50,18 @@ namespace SQRLUtilsLib
         /// <summary>
         /// The server component handling the Client-Protected-Session (CPS).
         /// </summary>
-        public SQRLCPSServer cps=null;
+        public static SQRLCPSServer CPS = null;
 
         /// <summary>
-        /// Creates a new instance of the SQRL library and optionally
-        /// starts the CPS server. This constructor is private, please use
-        /// <c>SQRL.GetInstance()</c> to obtain a <c>SQRL</c> instance.
-        /// </summary>
-        /// <param name="startCPS">Set to true if the CPS server should be started, or false otherwise.</param>
-        private SQRL(bool startCPS=false)
+        /// Starts the CPS server.
+        /// </summary>        
+        public static void StartCPSServer()
         {
-            Log.Information("Creating new SQRL library instance");
-
-            SodiumInit();
-
-            if (startCPS)
+            if (CPS == null)
             {
-                Log.Information("Starting CPS server");
-                this.cps = new SQRLCPSServer();
+                Log.Information("Creating CPS server");
+                CPS = SQRLCPSServer.Instance;
             }
-        }
-
-        /// <summary>
-        /// Returns a singleton instance of the SQRL library. If an instance
-        /// was already created before, it will be returned instead of creating
-        /// another one. Only on the first call of this method, a new instance 
-        /// will be created.
-        /// </summary>
-        /// <param name="startCPS">Set to true if the CPS server should be started, or false otherwise.</param>
-        public static SQRL GetInstance(bool startCPS = false)
-        {
-            if (_instance == null)
-            {
-                _instance = new Lazy<SQRL>(() => new SQRL(startCPS));
-            }
-
-            return _instance.Value;
         }
 
         /// <summary>

--- a/SQRLUtilsLib/SQRLCPSServer.cs
+++ b/SQRLUtilsLib/SQRLCPSServer.cs
@@ -223,7 +223,7 @@ namespace SQRLUtilsLib
             //Porbably need to figure out how to handle a timeout.
             foreach (var x in cpsBC.GetConsumingEnumerable())
             {
-                Log.Information($"CPS: Redirecting to: {x}");
+                Log.Information($"CPS: Redirecting to (omitting query params): {x.GetLeftPart(UriPartial.Path)}");
                 if (x.Equals(this.AbortURL))
                 {
 

--- a/SQRLUtilsLib/SQRLCPSServer.cs
+++ b/SQRLUtilsLib/SQRLCPSServer.cs
@@ -137,7 +137,7 @@ namespace SQRLUtilsLib
         {
             try
             {
-                var prefix = "http://localhost:" + Port.ToString() + "/";
+                var prefix = $"http://localhost:{Port}/";
                 _listener = new HttpListener();
                 _listener.Prefixes.Add(prefix);
                 Log.Information($"Start listening for CPS requests on {prefix}");


### PR DESCRIPTION
Fixes #102, closes #130.

### Description:

This basically implements all the ideas from #130, going for an an "always on" approach for CPS and enabling a CPS request to also trigger the auth dialog.

### Implementation:
Starting the CPS server is now decoupled from instantiating the SQRL library. In fact, the `SQRL` library class is purely static now, no need to instantiate it anymore.

Instead, the `SQRLCPSServer` class implements the singleton pattern. The `SQRL` class has a static function `SQRL.StartCPSServer()`, which does what its name suggests and gives access to the CPS server via the static property `SQRL.CPS`. The CPS server is now being started as soon as the app launches and stays running.

The CPS server now offers a new event called `CPSRequestReceived`, which the client makes use of in the `App` class by registering a handler that checks for new CPS requests containing `sqrl://` URIs to trigger the auth screen.

The `App` class now also receives IPC events, and acts as the central "broker" for those two services (CPS and IPC), so that they are not stepping on each other's toes.

This makes the (crippled) GRC SQRL demo site work with our client on Linux.