### PR TITLE
Drop CPS queries that contain an "Origin:" header

### DIFF
--- a/SQRLUtilsLib/SQRLCPSServer.cs
+++ b/SQRLUtilsLib/SQRLCPSServer.cs
@@ -161,7 +161,12 @@ namespace SQRLUtilsLib
                         // “Origin:” header which is not under the script’s control – and browser page - 
                         // fetch queries do not. Therefore, all SQRL clients must drop any query received 
                         // which contains an “Origin:” header.
-                        if (context.Request.Headers.AllKeys.Contains("Origin")) return;
+                        if (context.Request.Headers.AllKeys.Contains("Origin"))
+                        {
+                            context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
+                            context.Response.Close();
+                            return;
+                        }
 
                         // Looks like a legit request, so we can continue
                         CPSRequestReceivedEventArgs e = new CPSRequestReceivedEventArgs(context);

--- a/SQRLUtilsLib/SQRLCPSServer.cs
+++ b/SQRLUtilsLib/SQRLCPSServer.cs
@@ -150,6 +150,20 @@ namespace SQRLUtilsLib
                     try
                     {
                         HttpListenerContext context = _listener.GetContext();
+
+                        // We need to drop all requests containing an "Origin:" header!
+                        // Quoting from the spec:
+                        // If JavaScript were to use an XML HTTP Request (XHR), or similar, to query the 
+                        // SQRL web server at localhost: 25519, it would obtain the HTTP 302 redirect 
+                        // information returned by the web server, which it could abuse. Fortunately, web 
+                        // browser security strongly enforces the differentiation of any and all script-based 
+                        // queries from browser page fetch queries. ALL script-driven queries contain an 
+                        // “Origin:” header which is not under the script’s control – and browser page - 
+                        // fetch queries do not. Therefore, all SQRL clients must drop any query received 
+                        // which contains an “Origin:” header.
+                        if (context.Request.Headers.AllKeys.Contains("Origin")) return;
+
+                        // Looks like a legit request, so we can continue
                         CPSRequestReceivedEventArgs e = new CPSRequestReceivedEventArgs(context);
                         CPSRequestReceived?.Invoke(this, e);
                         if (e.ProcessEvent)


### PR DESCRIPTION
Closes #172 

### Description: 
This drops all CPS requests that contain an "Origin:" header.
For further details, please see #172.