### PR TITLE
Add spoofing protection (MITM/NO-CPS detection)

### DIFF
--- a/SQRLCommonUI/Models/PathConf.cs
+++ b/SQRLCommonUI/Models/PathConf.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Serilog;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
@@ -105,7 +106,25 @@ namespace SQRLCommonUI.Models
             }
             else
             {
-                _model = JsonSerializer.Deserialize<PathConfModel>(File.ReadAllText(ConfFile));
+                try
+                {
+                    _model = JsonSerializer.Deserialize<PathConfModel>(File.ReadAllText(ConfFile));
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"Error deserializing path config file:\r\n{ex}");
+                }
+                finally
+                {
+                    if (_model == null)
+                        _model = new PathConfModel();
+
+                    if (string.IsNullOrEmpty(_model.ClientInstallPath))
+                        _model.ClientInstallPath = DefaultClientInstallPath;
+
+                    if (string.IsNullOrEmpty(_model.ClientDBPath))
+                        _model.ClientDBPath = DefaultClientDBPath;
+                }
             }
         }
 

--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -164,14 +164,15 @@
     { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
     { "MissingLibGdiPlusErrorMessage": "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nYou will find install instructions on the project's Github Wiki." },
     { "UninstallMenuItemHeader": "Uninstall this app" },
-    { "SwitchDBMenuItemHeader": "Switch Database" },
     { "ReallyUninstallQuestion": "Are you really sure you want to uninstall the SQRL client application from your system?" },
+    { "SwitchDBMenuItemHeader": "Switch Database" },
     { "DbMoveQuestion": "Currently loadded DB File Is:\r\n\r\n{0}\r\n\r\nYou have chosen to load a new Db File:\r\n\r\n{1}\r\n\r\nWould you like to move this new Db File to the default SQRL Path at:\r\n\r\n{2}\r\n\r\n and then load it.\r\nOr should we just load this new Db in place?" },
     { "DbMoveAndLoad": "Move it and Load It" },
     { "DbJustLoad": "Just Load It" },
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
-    { "DbFileTitle": "Select a valid sqrl.db file" }
+    { "DbFileTitle": "Select a valid sqrl.db file" },
+    { "MITMAttackWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -338,14 +339,15 @@
     { "RadButExortWithRescueCode": "Require the super-secure Rescue Code for later decryption and use of the backup for maximum storage security." },
     { "MissingLibGdiPlusErrorMessage": "It seems that you are missing the \"libgdiplus\" library. Some parts of the app will not function correctly until this library is installed.\r\n\r\nYou will find install instructions on the project's Github Wiki." },
     { "UninstallMenuItemHeader": "Uninstall this app" },
-    { "SwitchDBMenuItemHeader": "Switch Database" },
     { "ReallyUninstallQuestion": "Are you really sure you want to uninstall the SQRL client application from your system?" },
+    { "SwitchDBMenuItemHeader": "Switch Database" },
     { "DbMoveQuestion": "Currently loadded DB File Is:\r\n\r\n{0}\r\n\r\nYou have chosen to load a new Db File:\r\n\r\n{1}\r\n\r\nWould you like to move this new Db File to the default SQRL Path at:\r\n\r\n{2}\r\n\r\n and then load it.\r\nOr should we just load this new Db in place?" },
     { "DbMoveAndLoad": "Move it and Load It" },
     { "DbJustLoad": "Just Load It" },
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
-    { "DbFileTitle": "Select a valid sqrl.db file" }
+    { "DbFileTitle": "Select a valid sqrl.db file" },
+    { "MITMAttackWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -512,13 +514,14 @@
     { "RadButExortWithRescueCode": "Erfordere den super-sicheren Rettungscode zur späteren Backup-Entschüsselung für maximale Sicherheit." },
     { "MissingLibGdiPlusErrorMessage": "Die wichtige Progrmmbibliothek \"libgdiplus\" fehlt. Einige Teile dieser App funktionieren nicht korrekt, solange diese Bibliothek nicht installiert ist.\r\n\r\nInstallationsanweisungen finden Sie im Projekt-Wiki auf Github." },
     { "UninstallMenuItemHeader": "App deinstallieren" },
-    { "SwitchDBMenuItemHeader": "Datenbank ändern" },
     { "ReallyUninstallQuestion": "Sind Sie wirklich sicher, dass Sie die SQRL Client-App deinstallieren möchten?" },
+    { "SwitchDBMenuItemHeader": "Datenbank ändern" },
     { "DbMoveQuestion": "Currently loadded DB File Is:\r\n\r\n{0}\r\n\r\nYou have chosen to load a new Db File:\r\n\r\n{1}\r\n\r\nWould you like to move this new Db File to the default SQRL Path at:\r\n\r\n{2}\r\n\r\n and then load it.\r\nOr should we just load this new Db in place?" },
     { "DbMoveAndLoad": "Move it and Load It" },
     { "DbJustLoad": "Just Load It" },
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
-    { "DbFileTitle": "Select a valid sqrl.db file" }
+    { "DbFileTitle": "Select a valid sqrl.db file" },
+    { "MITMAttackWarningMessage": "=== !! WARNUNG !! ===\r\n\r\nMöglicher Login-Angriff entdeckt\r\n\r\nSQRL hat festgestellt, dass Sie beim aktuellen Login-Vorgang einem sogenannten \"Spoofing\"-Angriff ausgesetzt sein könnten. Dabei gibt sich eine bösartige Webseite für eine andere aus, um an Ihre Zugangsdaten zu gelangen.\r\n\r\nSie sollten NUR fortfahren, wenn Sie wissen, was Sie tun!\r\n\r\nTrotzdem mit der Anmeldung fortfahren?" }
   ]
 }

--- a/SQRLDotNetClientUI/Assets/Localization/localization.json
+++ b/SQRLDotNetClientUI/Assets/Localization/localization.json
@@ -172,7 +172,8 @@
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
     { "DbFileTitle": "Select a valid sqrl.db file" },
-    { "MITMAttackWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
+    { "IPMismatchWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n(IP Mismatch)\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nAborting login." },
+    { "NoCPSWarningMessage": "=== !! WARNING !! ===\r\n\r\nMissing Identity Spoof Protection\r\n(No CPS)\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
   ],
   "en-US": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -347,7 +348,8 @@
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
     { "DbFileTitle": "Select a valid sqrl.db file" },
-    { "MITMAttackWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
+    { "IPMismatchWarningMessage": "=== !! WARNING !! ===\r\n\r\nPossible Login Attack Detected\r\n(IP Mismatch)\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nAborting login." },
+    { "NoCPSWarningMessage": "=== !! WARNING !! ===\r\n\r\nMissing Identity Spoof Protection\r\n(No CPS)\r\n\r\nThe website you were attempting to login to with SQRL may have been \"spoofing\" the actual website's identity in an attempt to capture your SQRL identity and use it to login to the real website as you.\r\n\r\nYou should ONLY be continuing if you know what you are doing!\r\n\r\nProceed with login anyway?" }
   ],
   "de-DE": [
     { "SQRLTag": "Secure Quick Reliable Login" },
@@ -522,6 +524,7 @@
     { "DbFileAlreadyLoaded": "The selected Db File is the same as the currently loaded Db File, try again by selecting a different file" },
     { "DbMoveError": "There was an error moving the Db file as requested, please try again. Error: {0}" },
     { "DbFileTitle": "Select a valid sqrl.db file" },
-    { "MITMAttackWarningMessage": "=== !! WARNUNG !! ===\r\n\r\nMöglicher Login-Angriff entdeckt\r\n\r\nSQRL hat festgestellt, dass Sie beim aktuellen Login-Vorgang einem sogenannten \"Spoofing\"-Angriff ausgesetzt sein könnten. Dabei gibt sich eine bösartige Webseite für eine andere aus, um an Ihre Zugangsdaten zu gelangen.\r\n\r\nSie sollten NUR fortfahren, wenn Sie wissen, was Sie tun!\r\n\r\nTrotzdem mit der Anmeldung fortfahren?" }
+    { "IPMismatchWarningMessage": "=== !! WARNUNG !! ===\r\n\r\nMöglicher Login-Angriff entdeckt (SameIP)\r\n\r\nSQRL hat festgestellt, dass Sie beim aktuellen Login-Vorgang einem sogenannten \"Spoofing\"-Angriff ausgesetzt sein könnten. Dabei gibt sich eine bösartige Webseite für eine andere aus, um Ihre Online-Identität zu stehlen.\r\n\r\nLogin-Vorgang abgebrochen." },
+    { "NoCPSWarningMessage": "=== !! WARNUNG !! ===\r\n\r\nFehlender \"Spoofing\"-Schutz (kein CPS)\r\n\r\nSQRL hat festgestellt, dass Sie beim aktuellen Login-Vorgang einem sogenannten \"Spoofing\"-Angriff ausgesetzt sein könnten. Dabei gibt sich eine bösartige Webseite für eine andere aus, um Ihre Online-Identität zu stehlen.\r\n\r\nSie sollten NUR fortfahren, wenn Sie wissen, was Sie tun!\r\n\r\nTrotzdem mit der Anmeldung fortfahren?" }
   ]
 }

--- a/SQRLUtilsLib/SQRLCPSServer.cs
+++ b/SQRLUtilsLib/SQRLCPSServer.cs
@@ -317,10 +317,10 @@ namespace SQRLUtilsLib
         /// <param name="succesUrl">Success URL passed in if the response is a successful Auth Ident</param>
         public static void HandlePendingCPS(string header = "", string message = "", string backUrlText = "", Uri succesUrl = null)
         {
-            /* There are some points in the application where all else fails and we still wantt o try and gracefully exit CPS
-             * in these instances we may not have access to the localization so we are hard coding these here as backup
-             * they only get called this way in extreme cases.
-             */
+            // There are some points in the application where all else fails and we still want to try and gracefully exit CPS.
+            // In these instances we may not have access to the localization so we are hardcoding these here as backup.
+            // They only get called this way in extreme cases.
+
             if (string.IsNullOrEmpty(header))
             {
                 header = "Authentication Aborted";


### PR DESCRIPTION
Closes #117.

### Description:
This adds detection and mitigation for the following scenarios:

- **The server reports an IP address mismatch** (TIF of `0x40`, "IPs matched" flag off)
In this case, we show a warning message and fail hard (just like the GRC client).

- **The server fails to engage CPS** 
In this case, we show a warning message and give the user the choice of aborting the authentication or continuing on (just like the GRC client).

### Additional changes:
- Hardening of the `PathConf.LoadConfig()` method since I was seeing a NPE in one particular case

- As discussed in #117, I've changed it so that we are now only sending the `cps` option if the server has already engaged a CPS session. What I was seeing when I reported that the GRC client sends `cps` right from the start makes sense, since CPS is usually so quickly engaged, that it will come in well before the "sqrl://" invocation, and so CPS is already there when we start sending commands to the server. 
On the spoofing demo site however, one can see that the GRC client in fact does NOT send `cps` if the server fails to engage CPS. So that's what we're now doing as well.

### Preview:

![mitm_mitigation](https://user-images.githubusercontent.com/4005543/81494073-1b643580-92a6-11ea-9049-c24be324b543.gif)
