### PR TITLE
Hide the "back" button on the export screen by default

### DIFF
--- a/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/ExportIdentityViewModel.cs
@@ -22,6 +22,7 @@ namespace SQRLDotNetClientUI.ViewModels
         private Avalonia.Media.Imaging.Bitmap _qrImage;
         private bool _exportWithPassword = true;
         private bool _showQrCode = false;
+        private bool _showBackButton = true;
 
         /// <summary>
         /// Gets a list of block types to export depending on the export
@@ -74,12 +75,23 @@ namespace SQRLDotNetClientUI.ViewModels
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not to display the
+        /// "back" button in the UI.
+        /// </summary>
+        public bool ShowBackButton
+        {
+            get { return _showBackButton; }
+            set { this.RaiseAndSetIfChanged(ref _showBackButton, value); }
+        }
+
+        /// <summary>
         /// Creates a new instance and initializes.
         /// </summary>
-        public ExportIdentityViewModel()
+        public ExportIdentityViewModel(bool showBackButton = false)
         {
             this.QRImage = null;
             this.Title = _loc.GetLocalizationValue("ExportIdentityWindowTitle");
+            this.ShowBackButton = showBackButton;
             this.Identity = _identityManager.CurrentIdentity;
 
             this.WhenAnyValue(x => x.ExportWithPassword)

--- a/SQRLDotNetClientUI/Views/ExportIdentityView.xaml
+++ b/SQRLDotNetClientUI/Views/ExportIdentityView.xaml
@@ -44,7 +44,7 @@
     <StackPanel DockPanel.Dock="Bottom">
       
       <DockPanel>
-        <Button Content="{loc:Localization BtnBack}" Command="{Binding Back}" DockPanel.Dock="Left" Width="120" HorizontalAlignment="Left" />
+        <Button Content="{loc:Localization BtnBack}" Command="{Binding Back}" IsVisible="{Binding ShowBackButton}" DockPanel.Dock="Left" Width="120" HorizontalAlignment="Left" />
         <Button Content="{loc:Localization BtnDone}" Command="{Binding Done}" DockPanel.Dock="Right" Width="120" HorizontalAlignment="Right" />
       </DockPanel>
 


### PR DESCRIPTION
Closes #178. 

### Description:
This hides the `Back` button in the "Export Identity" screen, since it neither makes sense to go "back" from this screen when launched from the "Create New Identity" wizard nor when coming directly from the main screen. The `Done` button should be all we need.

(I've left all the code and XAML for the `Back` button in, and if we do need it at some point, we can just set the new `showBackButton` parameter in the `ExportIdentityViewModel` constructor to `true`.)