### PR TITLE
Fix bug when creating db directory

### DIFF
--- a/SQRLDotNetClientUI/DB/DBContext/SQRLDBContext.cs
+++ b/SQRLDotNetClientUI/DB/DBContext/SQRLDBContext.cs
@@ -53,9 +53,9 @@ namespace SQRLDotNetClientUI.DB.DBContext
 
         protected override void OnConfiguring(DbContextOptionsBuilder options)
         {
-            if (!Directory.Exists(Path.GetDirectoryName(PathConf.ClientDBPath)))
+            if (!Directory.Exists(PathConf.ClientDBPath))
             {
-                Log.Information("Db Directory did not exist, creating");
+                Log.Information("DB directory did not exist, creating");
                 Directory.CreateDirectory(PathConf.ClientDBPath);
             }
 


### PR DESCRIPTION
### Description:

This fixes a bug that was introduced in PR #174 when trying to implement the following suggested change in my review:

> Couldn't we simply use `PathConf.ClientDbPath` here instead of `Path.GetDirectoryName(PathConf.FullClientDbPath)`?

Not omitting the `Path.GetDirectoryName()` when switching from `PathConf.FullClientDbPath` to `PathConf.ClientDbPath` would cause the correct directory to be created only if the PARENT directory of the db directory doesn't exist, which could get us in troubles.