### PR TITLE
Detect and install Microsoft Visual C++ Redistributable Runtime

### DIFF
--- a/SQRLPlatformAwareInstaller/Platform/Windows/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Windows/Installer.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.ComTypes;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace SQRLPlatformAwareInstaller.Platform.Windows
@@ -20,11 +19,25 @@ namespace SQRLPlatformAwareInstaller.Platform.Windows
             await Task.Run(() =>
             {
                 Log.Information($"Installing on Windows to {installPath}");
+
+                Log.Information($"Checking for Visual C++ redistributable runtime");
+                if (VcRedistHelper.IsRuntimeInstalled())
+                {
+                    Log.Warning("Visual C++ redistributable not found, installing");
+                    var exitCode = VcRedistHelper.InstallRuntime();
+                    Log.Information($"Installation of Visual C++ redistributable returned with exit code {exitCode}");
+                }
+                else
+                    Log.Information("Visual C++ redistributable was found");
+
                 Inventory.Instance.Load();
 
                 // Extract installation archive
                 Log.Information($"Extracting main installation archive");
                 Utils.ExtractZipFile(archiveFilePath, string.Empty, installPath);
+
+                // Check if a database exists in the installation directory 
+                // (which is bad) and if it does, move it to user space.
                 if (File.Exists(Path.Combine(installPath, PathConf.DBNAME)))
                 {
                     Utils.MoveDb(Path.Combine(installPath, PathConf.DBNAME));

--- a/SQRLPlatformAwareInstaller/Platform/Windows/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Windows/Installer.cs
@@ -21,7 +21,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Windows
                 Log.Information($"Installing on Windows to {installPath}");
 
                 Log.Information($"Checking for Visual C++ redistributable runtime");
-                if (VcRedistHelper.IsRuntimeInstalled())
+                if (!VcRedistHelper.IsRuntimeInstalled())
                 {
                     Log.Warning("Visual C++ redistributable not found, installing");
                     var exitCode = VcRedistHelper.InstallRuntime();

--- a/SQRLPlatformAwareInstaller/Platform/Windows/VcRedistHelper.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Windows/VcRedistHelper.cs
@@ -14,7 +14,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Windows
     public static class VcRedistHelper
     {
         /// <summary>
-        /// The direct download link to the Visual C++ Redistributable runtime executable.
+        /// The direct download link to the 64-bit version of the Visual C++ Redistributable runtime installer.
         /// </summary>
         public static readonly string VcRedistDownloadLink = 
             "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe";
@@ -59,9 +59,12 @@ namespace SQRLPlatformAwareInstaller.Platform.Windows
                 "vc_redist.x64.exe" : 
                 "vc_redist.x86.exe");
 
+            string downloadUrl = VcRedistDownloadLink;
+            if (!Environment.Is64BitProcess) downloadUrl = downloadUrl.Replace("x64", "x86");
+
             try
             {
-                wc.DownloadFile(VcRedistDownloadLink, downloadedFile);
+                wc.DownloadFile(downloadUrl, downloadedFile);
 
                 Process p = new Process();
                 p.StartInfo.FileName = downloadedFile;

--- a/SQRLPlatformAwareInstaller/Platform/Windows/VcRedistHelper.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Windows/VcRedistHelper.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.Win32;
+using Serilog;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+
+namespace SQRLPlatformAwareInstaller.Platform.Windows
+{
+    /// <summary>
+    /// A helper class for detecting and installing the Microsoft
+    /// Visual C++ Redistributable runtime on Windows.
+    /// </summary>
+    public static class VcRedistHelper
+    {
+        /// <summary>
+        /// The direct download link to the Visual C++ Redistributable runtime executable.
+        /// </summary>
+        public static readonly string VcRedistDownloadLink = 
+            "https://download.microsoft.com/download/9/3/F/93FCF1E7-E6A4-478B-96E7-D4B285925B00/vc_redist.x64.exe";
+
+        /// <summary>
+        /// Checks if the Visual C++ Redistributable runtime is installed on the system.
+        /// </summary>
+        public static bool IsRuntimeInstalled()
+        {
+            // First, we need to find the correct registry key to check for an existing
+            // Visual C++ Redistributable runtime installation. This depends upong the 
+            // bit-ness of the app and the OS.
+
+            // We default to 64-bit process running on a 64-bit OS
+            var vcRedistKeyStr = @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64";
+
+            if (!Environment.Is64BitProcess)
+            {
+                // We're running as a 32-bit process, check if the OS is 64 or 32 bits
+                vcRedistKeyStr = Environment.Is64BitOperatingSystem ?
+                    // 32-bit process on a 64-bit OS
+                    @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\x86" :
+                    // 32-bit process on a 32-bit OS
+                    @"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x86";
+            }
+
+            var vcRedistInstalled = Registry.GetValue(vcRedistKeyStr, "Installed", 0);
+
+            return (vcRedistInstalled != null && (int)vcRedistInstalled == 1);
+        }
+
+        /// <summary>
+        /// Tries to install the Visual C++ Redistributable runtime.
+        /// </summary>
+        /// <returns>Returns the exit code returned by the vc redistributable installer.</returns>
+        public static int InstallRuntime()
+        {
+            WebClient wc = new WebClient();
+
+            var downloadedFile = Path.Combine(Path.GetTempPath(),
+                Environment.Is64BitProcess ? 
+                "vc_redist.x64.exe" : 
+                "vc_redist.x86.exe");
+
+            try
+            {
+                wc.DownloadFile(VcRedistDownloadLink, downloadedFile);
+
+                Process p = new Process();
+                p.StartInfo.FileName = downloadedFile;
+                p.StartInfo.Arguments = "/install /passive /norestart";
+                p.StartInfo.UseShellExecute = true;
+                p.Start();
+                p.WaitForExit(1000 * 60 * 3); // 3 minutes
+
+                return p.ExitCode;
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Error downloading or installing VC++ redistributable:\r\n{ex}");
+                return -1;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #175. 

### Description:
This PR adds the capability for the Installer to detect a missing `Microsoft Visual C++ Redistributable Runtime` and silently download and install it.

I have only tested this on pure 64-bit. Any other combination (e.g. 32-bit Installer/Client on 64-bit OS, and also 32-bit Installer/Client on 32-bit OS) is untested.