### PR TITLE
Fix installer crashing when client is running during installation

### DIFF
--- a/SQRLPlatformAwareInstaller/Assets/Localization/localization.json
+++ b/SQRLPlatformAwareInstaller/Assets/Localization/localization.json
@@ -16,6 +16,8 @@
       "BtnFinish": "Finish",
       "InstallStatusInstalling": "Installing...",
       "InstallStatusDownloading": "Downloading...",
+      "InstallStatusWaitingForClientExit": "Waiting for SQRL client to be closed...",
+      "InstallStatusError": "Error during installion, please check log file and report to devs!",
       "SchemaRegistrationWarning": "WARNING: Exising sqrl:// schema registration found, if you proceed, it will be overwritten!",
       "SelectInstallVersionLabel": "Select version to install:",
       "DescriptionLabel": "Description:",
@@ -48,6 +50,8 @@
       "BtnFinish": "Finish",
       "InstallStatusInstalling": "Installing...",
       "InstallStatusDownloading": "Downloading...",
+      "InstallStatusWaitingForClientExit": "Waiting for SQRL client to be closed...",
+      "InstallStatusError": "Error during installion, please check log file and report to devs!",
       "SchemaRegistrationWarning": "WARNING: Exising sqrl:// schema registration found, if you proceed, it will be overwritten!",
       "SelectInstallVersionLabel": "Select version to install:",
       "DescriptionLabel": "Description:",
@@ -80,6 +84,8 @@
       "BtnFinish": "Fertig",
       "InstallStatusInstalling": "Installiere...",
       "InstallStatusDownloading": "Lade herunter...",
+      "InstallStatusWaitingForClientExit": "Warte, bis der SQRL-Client geschlossen wird...",
+      "InstallStatusError": "Fehler bei der Installation - bitte Logdatei überprüfen und den Entwicklern melden!",
       "SchemaRegistrationWarning": "WARNUNG: Existierende sqrl:// Schema-Registrierung gefunden, diese wird überschrieben!",
       "SelectInstallVersionLabel": "Version auswählen:",
       "DescriptionLabel": "Beschreibung:",
@@ -92,7 +98,7 @@
       "NoReleasesMessage": "Keine Releases verfügbar? Probieren Sie, Vorab-Releases zu aktivieren!",
       "TitleUninstall": "SQRL Client deinstallieren",
       "UninstallMessage": "Sie sind im Begriff, die SQRL Client-App von Ihrem Computer zu entfernen.\r\n\r\nSämtliche Programm-Daten werden dabei gelöscht. Ihre Benutzerdaten (z.B. ihre SQRL-Identitäten) bleiben dabei erhalten. Drücken Sie \"Deinstallieren\", um fortzufahren.",
-      "BtnUninstall":  "Deinstallieren"
+      "BtnUninstall": "Deinstallieren"
     }
   ]
 }

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -17,22 +17,22 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
         private static IBridgeSystem _bridgeSystem { get; set; } = BridgeSystem.Bash;
         private static ShellConfigurator _shell { get; set; } = new ShellConfigurator(_bridgeSystem);
 
+        #pragma warning disable 1998
         public async Task Install(string archiveFilePath, string installPath, string versionTag)
         {
-            Log.Information("Installing on Linux");
-            Inventory.Instance.Load();
-
-            if (!Directory.Exists(installPath))
-            {
-                Directory.CreateDirectory(installPath);
-            }
-
+            // The "async" in the delegate is needed, otherwise exceptions within
+            // the delegate won't "bubble up" to the exception handlers upstream.
             await Task.Run(() =>
             {
+                Inventory.Instance.Load();
+                Log.Information($"Installing on Linux to {installPath}");
+
+                // Extract main installation archive
                 Log.Information($"Extracting main installation archive");
                 Utils.ExtractZipFile(archiveFilePath, string.Empty, installPath);
 
-                //If the DB Exists in the current install path
+                // Check if a database exists in the installation directory 
+                // (which is bad) and if it does, move it to user space.
                 if (File.Exists(Path.Combine(installPath, PathConf.DBNAME)))
                 {
                     Utils.MoveDb(Path.Combine(installPath, PathConf.DBNAME));
@@ -40,48 +40,35 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 
                 Inventory.Instance.AddDirectory(installPath);
 
-                Log.Information("Copying installer into installation location (for auto update)");
-                try
-                {
-                    //Copy the installer but don't over-write the one included in the zip since it will likely be newer
-                    File.Copy(Process.GetCurrentProcess().MainModule.FileName, 
-                        Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName)), false);
-                }
-                catch (Exception fc)
-                {
-                    Log.Warning($"File copy exception while copying installer:\r\n{fc}");
-                }
-            });
-
-            Log.Information("Creating Linux desktop icon, application and registering SQRL invokation scheme");
-            await Task.Run(() =>
-            {
+                // Create icon, register sqrl:// scheme etc.
+                Log.Information("Creating Linux desktop icon, application and registering SQRL invokation scheme");
                 GitHubHelper.DownloadFile(@"https://github.com/sqrldev/SQRLDotNetClient/raw/master/SQRLDotNetClientUI/Assets/SQRL_icon_normal_64.png",
-                    Path.Combine(installPath, "SQRL.png"));
+                        Path.Combine(installPath, "SQRL.png"));
+
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine($"[Desktop Entry]");
+                sb.AppendLine("Name=SQRL");
+                sb.AppendLine("Type=Application");
+                sb.AppendLine($"Icon={(Path.Combine(installPath, "SQRL.png"))}");
+                sb.AppendLine($"Exec={GetClientExePath(installPath)} %u");
+                sb.AppendLine("Categories=Internet");
+                sb.AppendLine("Terminal=false");
+                sb.AppendLine("MimeType=x-scheme-handler/sqrl");
+                File.WriteAllText(Path.Combine(installPath, "sqrldev-sqrl.desktop"), sb.ToString());
+
+                _shell.Term($"chmod -R 755 {installPath}", Output.Internal);
+                _shell.Term($"chmod a+x {GetClientExePath(installPath)}", Output.Internal);
+                _shell.Term($"chmod +x {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
+                _shell.Term($"chmod a+x {Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName))}", Output.Internal);
+                _shell.Term($"xdg-desktop-menu install {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
+                _shell.Term($"gio mime x-scheme-handler/sqrl sqrldev-sqrl.desktop", Output.Internal);
+                _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl", Output.Internal);
+                _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
+
+                Inventory.Instance.Save();
             });
-
-            StringBuilder sb = new StringBuilder();
-            sb.AppendLine($"[Desktop Entry]");
-            sb.AppendLine("Name=SQRL");
-            sb.AppendLine("Type=Application");
-            sb.AppendLine($"Icon={(Path.Combine(installPath, "SQRL.png"))}");
-            sb.AppendLine($"Exec={GetClientExePath(installPath)} %u");
-            sb.AppendLine("Categories=Internet");
-            sb.AppendLine("Terminal=false");
-            sb.AppendLine("MimeType=x-scheme-handler/sqrl");
-            File.WriteAllText(Path.Combine(installPath, "sqrldev-sqrl.desktop"), sb.ToString());
-
-            _shell.Term($"chmod -R 755 {installPath}", Output.Internal);
-            _shell.Term($"chmod a+x {GetClientExePath(installPath)}", Output.Internal);
-            _shell.Term($"chmod +x {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
-            _shell.Term($"chmod a+x {Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName))}", Output.Internal);
-            _shell.Term($"xdg-desktop-menu install {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
-            _shell.Term($"gio mime x-scheme-handler/sqrl sqrldev-sqrl.desktop", Output.Internal);
-            _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl", Output.Internal);
-            _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
-
-            Inventory.Instance.Save();
         }
+        #pragma warning restore 1998
 
         public async Task Uninstall(IProgress<Tuple<int, string>> progress = null, bool dryRun = true)
         {

--- a/SQRLPlatformAwareInstaller/Utils.cs
+++ b/SQRLPlatformAwareInstaller/Utils.cs
@@ -51,6 +51,7 @@ namespace SQRLPlatformAwareInstaller
         {
             if (!Directory.Exists(outFolder))
             {
+                Log.Information($"Creating folder \"{outFolder}\"");
                 Directory.CreateDirectory(outFolder);
             }
 

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -13,6 +13,8 @@ using SQRLPlatformAwareInstaller.Models;
 using SQRLPlatformAwareInstaller.Platform;
 using System.Threading.Tasks;
 using Avalonia.Threading;
+using System.Diagnostics;
+using Avalonia.Media;
 
 namespace SQRLPlatformAwareInstaller.ViewModels
 {
@@ -29,6 +31,7 @@ namespace SQRLPlatformAwareInstaller.ViewModels
         private string _installationPath;
         private string _warning = "";
         private string _installStatus = "";
+        private IBrush _installStatusColor = Brushes.Black;
         private string _downloadedFileName;
         private GithubRelease[] _releases;
         private GithubRelease _selectedRelease;
@@ -74,6 +77,18 @@ namespace SQRLPlatformAwareInstaller.ViewModels
             set
             {
                 { this.RaiseAndSetIfChanged(ref _installStatus, value); }
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the text color of the install status lavbel.
+        /// </summary>
+        public IBrush InstallStatusColor
+        {
+            get { return this._installStatusColor; }
+            set
+            {
+                { this.RaiseAndSetIfChanged(ref _installStatusColor, value); }
             }
         }
 
@@ -256,18 +271,7 @@ namespace SQRLPlatformAwareInstaller.ViewModels
         private async void Wc_DownloadFileCompleted(object sender, System.ComponentModel.AsyncCompletedEventArgs e)
         {
             Log.Information("Download completed");
-
-            Dispatcher.UIThread.Post(() =>
-            {
-                this.InstallStatus = _loc.GetLocalizationValue("InstallStatusInstalling");
-                this.DownloadPercentage = 0;
-                this.IsProgressIndeterminate = true;
-            });
-
             await InstallOnPlatform(this._downloadedFileName);
-
-            ((MainWindowViewModel)_mainWindow.DataContext).Content = 
-                new InstallationCompleteViewModel(_installer.GetClientExePath(this.InstallationPath));
         }
 
         /// <summary>
@@ -277,14 +281,69 @@ namespace SQRLPlatformAwareInstaller.ViewModels
         /// <param name="downloadedFileName">The downloaded application files to install.</param>
         private async Task InstallOnPlatform(string downloadedFileName)
         {
+            // Set the progress bar to "indeterminate"
+            Dispatcher.UIThread.Post(() =>
+            {
+                this.DownloadPercentage = 0;
+                this.IsProgressIndeterminate = true;
+            });
+
             // Write the installation path to the config file so that
             // we can locate the installation later
-            Log.Information($"Writing installation path {this.InstallationPath} to config file");
+            Log.Information($"Writing installation path to config file: \"{this.InstallationPath}\"");
             PathConf.ClientInstallPath = this.InstallationPath;
+
+            // Check if client is running and kill it if necessary
+            Log.Information($"Checking if client is running");
+            var procName = Path.GetFileNameWithoutExtension(_installer.GetClientExePath(this.InstallationPath));
+            Process[] processes = Process.GetProcessesByName(procName);
+            if (processes.Length > 0)
+            {
+                var clientProcess = processes[0];
+
+                Log.Warning($"Client is running, trying to kill it");
+                clientProcess.Kill();
+
+                // Since the below call to "WaitForExit()" could potentially block
+                // forever if killing the client fails for some reason, we better
+                // give an indication of what's going on in the UI and hopefully have the
+                // user help out closing the client if our programmatic approach fails.
+                Dispatcher.UIThread.Post(() => this.InstallStatus = 
+                    _loc.GetLocalizationValue("InstallStatusWaitingForClientExit"));
+
+                await Task.Run(() => clientProcess.WaitForExit());
+
+                Log.Information($"Client exited, continuing");
+            }
+            else 
+                Log.Information($"Client not running, continuing");
+
+            // Set status "installing" in UI
+            Dispatcher.UIThread.Post(() => this.InstallStatus = 
+                _loc.GetLocalizationValue("InstallStatusInstalling"));
 
             // Perform the actual installation
             Log.Information($"Launching installation");
-            await _installer.Install(downloadedFileName, this.InstallationPath, this.SelectedRelease.tag_name);
+            try
+            {
+                await _installer.Install(downloadedFileName, this.InstallationPath, this.SelectedRelease.tag_name);
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"Error during installation:\r\n{ex}");
+                Dispatcher.UIThread.Post(() =>
+                {
+                    this.InstallStatusColor = Brushes.Red;
+                    this.InstallStatus = _loc.GetLocalizationValue("InstallStatusError");
+                    this.DownloadPercentage = 100;
+                    this.IsProgressIndeterminate = false;
+                });
+                
+                return;
+            }
+
+            ((MainWindowViewModel)_mainWindow.DataContext).Content =
+                new InstallationCompleteViewModel(_installer.GetClientExePath(this.InstallationPath));
         }
 
         /// <summary>

--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -295,8 +295,12 @@ namespace SQRLPlatformAwareInstaller.ViewModels
 
             // Check if client is running and kill it if necessary
             Log.Information($"Checking if client is running");
-            var procName = Path.GetFileNameWithoutExtension(_installer.GetClientExePath(this.InstallationPath));
-            Process[] processes = Process.GetProcessesByName(procName);
+            // On macOS, process names are truncated to 15 chararcters, 
+            // so we cannot match the full process name
+            var procName = Path.GetFileNameWithoutExtension(_installer.GetClientExePath(this.InstallationPath))
+                .Substring(0, 15);
+            Process[] processes = Process.GetProcesses()
+                .Where(x => x.ProcessName.StartsWith(procName)).ToArray();
             if (processes.Length > 0)
             {
                 var clientProcess = processes[0];

--- a/SQRLPlatformAwareInstaller/Views/VersionSelectorView.xaml
+++ b/SQRLPlatformAwareInstaller/Views/VersionSelectorView.xaml
@@ -54,7 +54,7 @@
       <Button Content="{loc:Localization BtnInstallPath}" Margin="0,10" Grid.Row="6" Grid.Column="0" Command="{Binding FolderPicker}" />
       <TextBox Margin="10" Width="400" MaxWidth="400" HorizontalAlignment="Left" Grid.Row="6" Grid.Column="1" Text="{Binding InstallationPath}" IsReadOnly="True"/>
       <StackPanel Margin="0,10" Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Vertical">
-        <TextBlock Text="{Binding InstallStatus}" FontWeight="Bold" />
+        <TextBlock Text="{Binding InstallStatus}" Foreground="{Binding InstallStatusColor}" FontWeight="Bold" />
         <ProgressBar Value="{Binding DownloadPercentage}" IsIndeterminate="{Binding IsProgressIndeterminate}" Maximum="100" Margin="0,10,0,0" />
       </StackPanel>
       <TextBlock FontWeight="Bold"  Margin="0,10" HorizontalAlignment="Left" Width="580" MaxWidth="580" Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2" Text="{Binding Warning}" TextWrapping="Wrap"/>


### PR DESCRIPTION
Fixes #188. 

### Description:
This fixes a bug where the installer would crash while extracting the installation archive when one of the files being extracted is in use.

### Implementation:
- Check running processes, and if client process is found, try killing it before starting the installation
- If any other file than the client executable is in use, catch the exception and abort the installation with a message in the UI

### Additional changes:
- Remove the copying of the installer to the install directory, this is not needed anymore since the installer is contained in the installation archive anyway.

