### PR TITLE
Change default install path on Linux

### DIFF
--- a/SQRLCommonUI/Models/PathConf.cs
+++ b/SQRLCommonUI/Models/PathConf.cs
@@ -16,8 +16,11 @@ namespace SQRLCommonUI.Models
     {
         private static PathConfModel _model = new PathConfModel();
 
+        /// <summary>
+        /// The file name, excluding the path, of the client database file.
+        /// </summary>
         public static readonly string DBNAME = "sqrl.db";
-        
+
         /// <summary>
         /// The full file path of the config file.
         /// </summary>
@@ -29,20 +32,10 @@ namespace SQRLCommonUI.Models
         /// The default client installation directory.
         /// </summary>
         public static readonly string DefaultClientInstallPath = RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ?
-            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "SQRL") :
+            Path.Combine("/opt", "SQRL") :
             RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ?
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles)) :
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "SQRL");
-
-
-        public static string FullClientDbPath
-        {
-            get
-            {
-                LoadConfig();
-                return Path.Combine(_model.ClientDBPath, PathConf.DBNAME);
-            }
-        }
 
         /// <summary>
         /// The default client database directory.
@@ -81,6 +74,18 @@ namespace SQRLCommonUI.Models
             {
                 _model.ClientDBPath = value;
                 SaveConfig();
+            }
+        }
+
+        /// <summary>
+        /// The full file path, including the file name, to the client database.
+        /// </summary>
+        public static string FullClientDbPath
+        {
+            get
+            {
+                LoadConfig();
+                return Path.Combine(_model.ClientDBPath, PathConf.DBNAME);
             }
         }
 
@@ -144,10 +149,7 @@ namespace SQRLCommonUI.Models
             Directory.CreateDirectory(Path.GetDirectoryName(ConfFile));
             string serialized = JsonSerializer.Serialize(_model, _model.GetType(), options);
             File.WriteAllText(ConfFile, serialized);
-        }
-
-
-        
+        }   
     }
 
     /// <summary>

--- a/SQRLPlatformAwareInstaller/App.xaml.cs
+++ b/SQRLPlatformAwareInstaller/App.xaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Markup.Xaml;
 using SQRLCommonUI.AvaloniaExtensions;
 using SQRLPlatformAwareInstaller.ViewModels;
 using SQRLPlatformAwareInstaller.Views;
+using System.Runtime.InteropServices;
 
 namespace SQRLPlatformAwareInstaller
 {
@@ -11,6 +12,15 @@ namespace SQRLPlatformAwareInstaller
     {
         public override void Initialize()
         {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || 
+                RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                if (!Utils.IsAdmin())
+                {
+                    throw new System.Exception("This app must be run as an administrator in Windows or sudo/root in Linux");
+                }
+            }
+
             AvaloniaXamlLoader.Load(this);
 
             // This is here only to be able to manually load a specific translation 

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -56,7 +56,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 sb.AppendLine("MimeType=x-scheme-handler/sqrl");
                 File.WriteAllText(Path.Combine(installPath, "sqrldev-sqrl.desktop"), sb.ToString());
 
-                _shell.Term($"chmod -R 750 {installPath}", Output.Internal);
+                _shell.Term($"chmod -R 755 {installPath}", Output.Internal);
                 _shell.Term($"chmod +x {GetClientExePath(installPath)}", Output.Internal);
                 _shell.Term($"chmod +x {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
                 _shell.Term($"chmod +x {Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName))}", Output.Internal);
@@ -65,13 +65,10 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl", Output.Internal);
                 _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
 
-                // Change owner of installed files to the actual user behind the "sudo"
+                // Change owner of database dir/file to the actual user behind the "sudo"
                 string user = _shell.Term("logname", Output.Hidden).stdout.Trim();
-                string chownInstallDir = $"chown -R {user}:{user} {installPath}";
                 string chownDbFile = $"chown -R {user}:{user} {PathConf.ClientDBPath}";
                 Log.Information($"Determined username for chown: \"{user}\"");
-                Log.Information($"Running command: {chownInstallDir}");
-                _shell.Term(chownInstallDir, Output.Internal);
                 Log.Information($"Running command: {chownDbFile}");
                 _shell.Term(chownDbFile, Output.Internal);
 

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -68,7 +68,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 // Change owner of installed files to the actual user behind the "sudo"
                 string user = _shell.Term("logname", Output.Hidden).stdout.Trim();
                 string chownInstallDir = $"chown -R {user}:{user} {installPath}";
-                string chownDbFile = $"chown {user}:{user} {PathConf.FullClientDbPath}";
+                string chownDbFile = $"chown -R {user}:{user} {PathConf.ClientDBPath}";
                 Log.Information($"Determined username for chown: \"{user}\"");
                 Log.Information($"Running command: {chownInstallDir}");
                 _shell.Term(chownInstallDir, Output.Internal);

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -66,10 +66,14 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
 
                 // Change owner of installed files to the actual user behind the "sudo"
-                var user = _shell.Term("logname", Output.Internal).stdout;
-                Log.Information($"Determined username for chown: {user}");
-                _shell.Term($"chown -R {user}:{user} {installPath}", Output.Internal);
-                _shell.Term($"chown {user}:{user} {PathConf.FullClientDbPath}", Output.Internal);
+                string user = _shell.Term("logname", Output.Hidden).stdout;
+                string chownInstallDir = $"chown -R {user}:{user} {installPath}";
+                string chownDbFile = $"chown {user}:{user} {PathConf.FullClientDbPath}";
+                Log.Information($"Determined username for chown: \"{user}\"");
+                Log.Information($"Running command: {chownInstallDir}");
+                _shell.Term(chownInstallDir, Output.Internal);
+                Log.Information($"Running command: {chownDbFile}");
+                _shell.Term(chownDbFile, Output.Internal);
 
                 Inventory.Instance.Save();
             });

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -66,7 +66,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
 
                 // Change owner of installed files to the actual user behind the "sudo"
-                string user = _shell.Term("logname", Output.Hidden).stdout;
+                string user = _shell.Term("logname", Output.Hidden).stdout.Trim();
                 string chownInstallDir = $"chown -R {user}:{user} {installPath}";
                 string chownDbFile = $"chown {user}:{user} {PathConf.FullClientDbPath}";
                 Log.Information($"Determined username for chown: \"{user}\"");

--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -56,14 +56,20 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
                 sb.AppendLine("MimeType=x-scheme-handler/sqrl");
                 File.WriteAllText(Path.Combine(installPath, "sqrldev-sqrl.desktop"), sb.ToString());
 
-                _shell.Term($"chmod -R 755 {installPath}", Output.Internal);
-                _shell.Term($"chmod a+x {GetClientExePath(installPath)}", Output.Internal);
+                _shell.Term($"chmod -R 750 {installPath}", Output.Internal);
+                _shell.Term($"chmod +x {GetClientExePath(installPath)}", Output.Internal);
                 _shell.Term($"chmod +x {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
-                _shell.Term($"chmod a+x {Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName))}", Output.Internal);
+                _shell.Term($"chmod +x {Path.Combine(installPath, Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName))}", Output.Internal);
                 _shell.Term($"xdg-desktop-menu install {Path.Combine(installPath, "sqrldev-sqrl.desktop")}", Output.Internal);
                 _shell.Term($"gio mime x-scheme-handler/sqrl sqrldev-sqrl.desktop", Output.Internal);
                 _shell.Term($"xdg-mime default sqrldev-sqrl.desktop x-scheme-handler/sqrl", Output.Internal);
                 _shell.Term($"update-desktop-database ~/.local/share/applications/", Output.Internal);
+
+                // Change owner of installed files to the actual user behind the "sudo"
+                var user = _shell.Term("logname", Output.Internal).stdout;
+                Log.Information($"Determined username for chown: {user}");
+                _shell.Term($"chown -R {user}:{user} {installPath}", Output.Internal);
+                _shell.Term($"chown {user}:{user} {PathConf.FullClientDbPath}", Output.Internal);
 
                 Inventory.Instance.Save();
             });

--- a/SQRLPlatformAwareInstaller/ViewModels/InstallationCompleteViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/InstallationCompleteViewModel.cs
@@ -2,6 +2,8 @@
 using Serilog;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
+using ToolBox.Bridge;
 
 namespace SQRLPlatformAwareInstaller.ViewModels
 {
@@ -73,6 +75,13 @@ namespace SQRLPlatformAwareInstaller.ViewModels
             process.StartInfo.FileName = _clientExePath;
             process.StartInfo.WorkingDirectory = Path.GetDirectoryName(_clientExePath);
             process.StartInfo.UseShellExecute = true;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                ShellConfigurator shell = new ShellConfigurator(BridgeSystem.Bash);
+                string user = shell.Term("logname", Output.Hidden).stdout.Trim();
+                process.StartInfo.UserName = user;
+                process.StartInfo.UseShellExecute = false;
+            }
             process.Start();
         }
     }


### PR DESCRIPTION
Closes #191. 

### Description:
As discussed in #191, this changes the default install path on Linux to `/opt/SQRL`, so that it won't clash with our user data which is stored in `/home/$USER/SQRL`.

### Changes:
Following changes were required as a result of this change:
- The initial installation now needs to be run with `sudo`, since that's required to write to `/opt`.
- The Linux installer will then `chown` the install and database directories to the actual user
- Changed default file permissions from `755` to `750`