### PR TITLE
Disable changing install path on macOS

### DIFF
--- a/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
+++ b/SQRLPlatformAwareInstaller/ViewModels/VersionSelectorViewModel.cs
@@ -166,6 +166,15 @@ namespace SQRLPlatformAwareInstaller.ViewModels
         }
 
         /// <summary>
+        /// Gets a value indicating whether it should be allowed for the user to change
+        /// the installation path through the UI.
+        /// </summary>
+        public bool CanChangeInstallPath
+        {
+            get { return !RuntimeInformation.IsOSPlatform(OSPlatform.OSX); }
+        }
+
+        /// <summary>
         /// Creates a new instance and performs some initializations.
         /// </summary>
         public VersionSelectorViewModel()

--- a/SQRLPlatformAwareInstaller/Views/VersionSelectorView.xaml
+++ b/SQRLPlatformAwareInstaller/Views/VersionSelectorView.xaml
@@ -51,7 +51,7 @@
         <TextBlock TextWrapping="Wrap" Margin="3,0,0,0">MB</TextBlock>
       </StackPanel>
     
-      <Button Content="{loc:Localization BtnInstallPath}" Margin="0,10" Grid.Row="6" Grid.Column="0" Command="{Binding FolderPicker}" />
+      <Button Content="{loc:Localization BtnInstallPath}" Command="{Binding FolderPicker}" IsEnabled="{Binding CanChangeInstallPath}" Margin="0,10" Grid.Row="6" Grid.Column="0" />
       <TextBox Margin="10" Width="400" MaxWidth="400" HorizontalAlignment="Left" Grid.Row="6" Grid.Column="1" Text="{Binding InstallationPath}" IsReadOnly="True"/>
       <StackPanel Margin="0,10" Grid.Row="7" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Vertical">
         <TextBlock Text="{Binding InstallStatus}" Foreground="{Binding InstallStatusColor}" FontWeight="Bold" />


### PR DESCRIPTION
Closes #193. 

### Description:
This disables changing the install path on macOS in the UI.