### PR TITLE
Add missing "async" keyword in linux installer

### DIFF
--- a/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
+++ b/SQRLPlatformAwareInstaller/Platform/Linux/Installer.cs
@@ -24,7 +24,7 @@ namespace SQRLPlatformAwareInstaller.Platform.Linux
         {
             // The "async" in the delegate is needed, otherwise exceptions within
             // the delegate won't "bubble up" to the exception handlers upstream.
-            await Task.Run(() =>
+            await Task.Run(async () =>
             {
                 Inventory.Instance.Load();
                 Log.Information($"Installing on Linux to {installPath}");


### PR DESCRIPTION
### Description:
Small fix that adds a missing `async` keyword in the linux installer delegate which would prevent exceptions from "bubbling upstream" and being caught properly.