### PR TITLE
Fix client update crash on macOS

### DIFF
--- a/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
+++ b/SQRLDotNetClientUI/ViewModels/MainMenuViewModel.cs
@@ -449,12 +449,13 @@ namespace SQRLDotNetClientUI.ViewModels
 
                 Process proc = new Process();
                 proc.StartInfo.FileName = installerTempFilePath;
+                proc.StartInfo.WorkingDirectory = Path.GetDirectoryName(installerTempFilePath);
                 proc.StartInfo.Arguments = arguments;
+                proc.StartInfo.UseShellExecute = true;
                 Log.Information($"Installer location: {proc.StartInfo.FileName}");
                 Log.Information($"Installer arguments: {proc.StartInfo.Arguments}");
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                 {
-                    proc.StartInfo.UseShellExecute = true;
                     proc.StartInfo.Verb = "runas";
                 }
                 proc.Start();


### PR DESCRIPTION
### Description:

I finally fixed my macOS VM and was able to test the latest bits. This fixes an issue with launching the installer from the client when installing an update.

It seems that not using `Process.StartInfo.UseShellExecute = true;` on macOS when invoking the installer process was causing the client to crash.